### PR TITLE
Add official BRIK64 agent operating skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,21 @@
-# BRIK-64 Agent Skills
+# BRIK64 Agent Skills
 
-Five skills covering Digital Circuitality from theory to production, including the Registry platform and minimalist MCP interface.
+Public BRIK64 skills for AI agents and developers working with the local CLI,
+PCD, `.brik` traceability, Digital Circuitality, and language SDKs.
+
+For current product documentation, always check https://docs.brik64.com.
+Agents should also review this repository periodically before important BRIK64
+work so installed instructions do not drift from the public skill source.
 
 ---
 
-## Which skills do I need?
+## Which skill do I need?
 
 ```
+Are you an AI agent using the public brik CLI, .brik, PCD 1.0, local evidence,
+or AGENTS.md managed instructions?
+  └─ YES → install: brik64
+
 Are you learning the theory / designing with circuit thinking?
   └─ YES → install: digital-circuitality
 
@@ -15,25 +24,42 @@ Are you using brik64 libraries in an existing codebase?
   ├─ JavaScript / TypeScript → install: brik64-javascript
   └─ Python             → install: brik64-python
 
-Are you writing PCD programs, using brik64 CLI, or building policy circuits?
+Are you writing lower-level PCD programs or using older PCD reference material?
   └─ YES → install: pcd-system
 
 Are you working with the BRIK-64 Registry, MCP, or Marketplace?
   └─ YES → install: pcd-system (includes Registry/MCP section)
 ```
 
-Install all 5 for full coverage. Each skill is independent.
+Install `brik64` first for current public beta agent operation. Add the
+language or theory skills only when the task needs them. Each skill is
+independent.
 
 Public naming contract:
 
-- public CLI name: `brik64`
-- internal compiler/testing name: `brikc`
-- during alpha transition some engineering artifacts may still carry `brikc` as
-  a compatibility or legacy identifier
+- current public CLI command: `brik`
+- current public npm package: `@brik64/cli@0.1.0-beta.2`
+- current docs: https://docs.brik64.com
+- internal or older engineering artifacts may still carry `brik64` or `brikc`
+  identifiers; report drift instead of presenting legacy names as current truth
 
 ---
 
 ## Skills
+
+### `brik64`
+**Current public operating skill for AI agents using BRIK64.**
+
+Use this first when an agent is working with the public `brik` CLI, `.brik`
+metadata, PCD 1.0, local evidence, `AGENTS.md` managed instructions, or public
+BRIK64 docs. It includes the current CLI beta install path, docs lookup rule,
+periodic repository update rule, consent-based skill installation workflow, and
+claim-safe reporting boundaries.
+
+Install when: you are an AI coding agent, reviewing a BRIK64 project, using
+`brik`, writing PCD candidates, or preparing a public-facing BRIK64 report.
+
+---
 
 ### `digital-circuitality`
 **The circuit thinking methodology — language agnostic.**
@@ -45,9 +71,11 @@ Install when: you are designing a system, reviewing architecture, or want to und
 ---
 
 ### `pcd-system`
-**The complete PCD + brik64 CLI + Registry environment.**
+**Detailed PCD reference and legacy/deeper PCD system notes.**
 
-Full reference for writing PCD programs, compiling with `brik64`, certifying circuits (Φ_c = 1), debugging CMF errors, building AI safety policy circuits, and targeting multiple backends (native ELF, Rust, JS, Python, WASM).
+Use alongside `brik64` when a task needs deeper PCD examples, syntax notes, or
+older system material. Treat older version labels in this skill as historical
+unless current docs and release evidence confirm them.
 
 **NEW in v5.0:** Includes Domain Declaration System, function parameter domains, compile-time warnings, and the BRIK-64 Registry & MCP platform layer — the 2-tool minimalist MCP architecture (`brik64.discover` + `brik64.execute`), inherited certification, domain packs, the Reuse Before Create workflow, and the API/Marketplace reference.
 
@@ -62,7 +90,8 @@ Install when: you are writing `.pcd` files, using the brik64 compiler, building 
 
 The `brik64-core` crate brings all 128 monomers (64 core + 64 extended) and EVA algebra operators to native Rust. Use saturating arithmetic, verified crypto, and composable pipelines directly in your Rust code. No PCD files, no compiler invocation.
 
-Install when: you are working in a Rust project and want verified, formally-proven operations without adopting PCD.
+Install when: you are working in a Rust project and want BRIK64 operation
+patterns without adopting PCD.
 
 ---
 
@@ -80,7 +109,8 @@ Install when: you are working in a JS/TS project and want Digital Circuitality p
 
 The `brik64` PyPI package brings 128 monomers (64 core + 64 extended) to Python 3.10+. Identical semantics to the Rust and JS versions. Pipeline composition via `eva.pipeline()`.
 
-Install when: you are working in a Python project and want verified, formally-proven operations without adopting PCD.
+Install when: you are working in a Python project and want BRIK64 operation
+patterns without adopting PCD.
 
 ---
 
@@ -88,15 +118,14 @@ Install when: you are working in a Python project and want verified, formally-pr
 
 | Goal | Skills to install |
 |------|------------------|
+| AI agent using current public BRIK64 beta | `brik64` |
 | Understand Digital Circuitality | `digital-circuitality` |
-| Write PCD programs | `pcd-system` |
-| Build AI safety policy circuits | `pcd-system` |
-| Use BRIK-64 Registry / MCP | `pcd-system` |
+| Write current PCD candidates with CLI workflow | `brik64` + `pcd-system` |
+| Use AGENTS.md managed instructions | `brik64` |
 | BRIK-64 operations in Rust | `brik64-rust` |
 | BRIK-64 operations in JS/TS | `brik64-javascript` |
 | BRIK-64 operations in Python | `brik64-python` |
-| Full stack: theory + PCD + all languages | all 5 |
-| AI agent with Registry access | `pcd-system` (Registry + MCP section) |
+| Full public beta agent workflow | `brik64` + `digital-circuitality` + `pcd-system` |
 
 ---
 

--- a/skills/brik64/SKILL.md
+++ b/skills/brik64/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: brik64
+description: Public BRIK64 operating skill for AI agents using the brik CLI, .brik traceability, PCD 1.0, local evidence, and claim-safe workflows. Use when working with BRIK64 projects, PCD files, agent instructions, CLI commands, evidence reports, or public BRIK64 documentation.
+version: 0.1.0-beta.2
+triggers:
+  - using brik CLI
+  - BRIK64 project workflow
+  - writing or reviewing PCD 1.0
+  - creating .brik traceability
+  - installing BRIK64 AGENTS.md instructions
+  - reviewing local evidence
+  - preparing claim-safe reports
+  - checking docs.brik64.com
+---
+
+# BRIK64 Agent Operating Skill
+
+Use this skill when acting as an AI agent inside a BRIK64 project or when
+helping a user adopt the public BRIK64 CLI beta.
+
+BRIK64 is a local-first workflow for making critical software logic easier to
+inspect, describe, compose, and review with bounded evidence. The current public
+CLI package is `@brik64/cli@0.1.0-beta.2`.
+
+Primary documentation:
+
+- Docs: https://docs.brik64.com
+- CLI install: https://docs.brik64.com/cli/install
+- GitHub Release: https://github.com/brik64/brik64-cli/releases/tag/v0.1.0-beta.2
+- npm package: https://www.npmjs.com/package/@brik64/cli
+- Public skills repo: https://github.com/brik64/brik64-tools-skills
+
+## Agent Rule
+
+Do not start by writing code. Start by shaping the requirement into a bounded
+circuit:
+
+```text
+requirement -> inputs and outputs -> fail-closed behavior -> PCD Blueprint
+-> EVA structure -> Polymer candidate -> .brik traceability -> local evidence
+-> bounded report
+```
+
+## Keep The Skill Current
+
+Before important work, check the live docs and the public skills repository:
+
+1. Read the relevant page on https://docs.brik64.com.
+2. Check the current `brik64-tools-skills` repository or installed skill version.
+3. Prefer the newer public docs/repo state over stale local notes.
+4. If local instructions conflict with live docs, report the drift and follow the
+   more authoritative current public source unless the user provides a stricter
+   repo-local policy.
+
+For recurring or long-running projects, re-check docs and the skills repository
+periodically, especially before publishing, installing agent instructions,
+reporting evidence, or describing release status.
+
+## Install And Verify The CLI
+
+Use npm for the current public beta:
+
+```bash
+npm install -g @brik64/cli@beta
+brik --version
+brik help
+```
+
+Current version boundary:
+
+- Public package/release version: `0.1.0-beta.2`
+- Runtime banner may still report: `0.1.0-beta.0`
+
+Treat runtime output as observed evidence. Treat package metadata and GitHub
+Release as the public package surface. If they disagree, report the drift instead
+of hiding it.
+
+## `.brik` Traceability
+
+Use `.brik` as local project metadata for BRIK64 work:
+
+- project manifest;
+- decisions and evidence references;
+- local candidate artifacts;
+- update and release notes where supported by the CLI.
+
+Rules:
+
+- `brik init` prepares local BRIK64 metadata.
+- `brik init` must not create or modify `AGENTS.md`.
+- Do not store secrets, raw tokens, private keys, or private source snapshots in
+  `.brik`.
+- Treat `.brik` metadata as operational traceability, not as certification.
+
+## PCD 1.0 Working Model
+
+PCD means Polymer Circuit Description. In public beta work, treat PCD as a
+reviewable structural description for logic, not as a free-form script.
+
+Agent checklist for PCD work:
+
+- Declare inputs and outputs.
+- Name failure behavior.
+- Keep monomer selection explicit.
+- Keep EVA composition explicit.
+- Preserve generated files and evidence references.
+- Review generated PCD before using it in a larger composition.
+- Do not claim that a PCD candidate certifies an entire application.
+
+Use docs before writing PCD:
+
+- https://docs.brik64.com/language/pcd-file-standard
+- https://docs.brik64.com/language/pcd-syntax
+- https://docs.brik64.com/language/pcd-tutorial
+- https://docs.brik64.com/agents/pcd-authoring-rules
+
+## CLI Workflow
+
+Useful public beta commands:
+
+```bash
+brik help
+brik version
+brik --version
+brik doctor
+brik init
+brik pcd generate order-risk
+brik certify
+brik polymerize
+brik compile all
+brik test all
+brik update check
+brik update install --manifest manifest.json
+brik engine status
+```
+
+Use commands only within their documented scope. If a command is missing or
+behaves differently in the installed beta, report the observed output and the
+installed package version.
+
+## Agent Instructions In `AGENTS.md`
+
+BRIK64 agent instructions are written only with explicit user consent.
+
+Preview first:
+
+```bash
+brik skill diff --target AGENTS.md
+```
+
+Install:
+
+```bash
+brik skill install --target AGENTS.md
+```
+
+Update:
+
+```bash
+brik skill update --target AGENTS.md
+```
+
+Remove:
+
+```bash
+brik skill remove --target AGENTS.md
+```
+
+Check:
+
+```bash
+brik skill doctor
+```
+
+Rules:
+
+- `--target AGENTS.md` is the explicit write target.
+- Preserve human-authored content outside the managed BRIK64 section.
+- Report exactly what changed.
+- The managed section is guidance for agents. It is not a certificate for the
+  repository.
+
+## Evidence And Certification Boundaries
+
+Use precise language:
+
+- local candidate;
+- local evidence;
+- smoke report;
+- release evidence;
+- package metadata;
+- GitHub Release;
+- public claim authorization.
+
+Do not claim any of the following unless the current public evidence proves the
+exact scope:
+
+- formal certification of an application;
+- N4/N5, L5+/L6+, self-hosting, Rust independence, fixpoint, or proof;
+- universal correctness;
+- complete platform support;
+- bundled runtime motor, unless the release artifact shows it.
+
+If evidence is missing, say what is missing and keep the result scoped.
+
+## Reporting Template
+
+When closing work, report:
+
+```text
+BRIK64 status:
+- Package:
+- Runtime output:
+- Docs checked:
+- Commands run:
+- Files changed:
+- Evidence produced:
+- Claim boundary:
+- Open blockers:
+```
+
+## Public Surface Rule
+
+BRIK64 public surfaces should be confident but bounded. Prefer:
+
+```text
+This produces local evidence for the inspected scope.
+```
+
+Avoid:
+
+```text
+This proves the whole application is correct.
+```
+
+## Source Authority Order
+
+Use this order when facts conflict:
+
+1. Current repo files and command output.
+2. https://docs.brik64.com.
+3. Current GitHub Release and package metadata.
+4. Public `brik64-tools-skills` repository.
+5. Older local notes or chat context.
+
+When a fact is drift-prone, verify it again before publishing or reporting it.


### PR DESCRIPTION
## Summary
- Add the current public BRIK64 operating skill for AI agents.
- Cover brik CLI beta usage, .brik traceability, PCD 1.0 workflow, local evidence, AGENTS.md consent commands, docs lookup, periodic skills repo refresh, and claim-safe reporting.
- Update README so agents install brik64 first for the current public beta workflow.
- Downgrade older SDK wording that implied formally-proven operations without current public evidence in this repo.

## Validation
- Claim-sensitive term scan on README and the new brik64 skill.
- Signed commit verified locally.

Public skill/docs change; no certification or runtime claim expansion.