### PR TITLE
Align public skills with beta surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ Are you using brik64 libraries in an existing codebase?
 Are you writing lower-level PCD programs or using older PCD reference material?
   └─ YES → install: pcd-system
 
-Are you working with the BRIK-64 Registry, MCP, or Marketplace?
-  └─ YES → install: pcd-system (includes Registry/MCP section)
 ```
 
 Install `brik64` first for current public beta agent operation. Add the
@@ -77,18 +75,20 @@ Use alongside `brik64` when a task needs deeper PCD examples, syntax notes, or
 older system material. Treat older version labels in this skill as historical
 unless current docs and release evidence confirm them.
 
-**NEW in v5.0:** Includes Domain Declaration System, function parameter domains, compile-time warnings, and the BRIK-64 Registry & MCP platform layer — the 2-tool minimalist MCP architecture (`brik64.discover` + `brik64.execute`), inherited certification, domain packs, the Reuse Before Create workflow, and the API/Marketplace reference.
+Covers: PCD syntax notes, monomer-oriented examples, older command examples,
+and historical PCD system material. Use current docs and the `brik64` skill for
+the public beta CLI workflow.
 
-Covers: PCD syntax, all 128 monomers (64 core + 64 extended) with signatures, CMF metrics, known bugs and workarounds, brik64 CLI commands, auto-generated test suites, policy circuit templates, Registry MCP tools, domain packs, composition API.
-
-Install when: you are writing `.pcd` files, using the brik64 compiler, building ALLOW/BLOCK guardrails for AI agents, or working with the BRIK-64 Registry/MCP/Marketplace.
+Install when: you are writing `.pcd` files or need deeper PCD reference notes.
 
 ---
 
 ### `brik64-rust`
 **Use brik64-core in Rust — no public CLI needed.**
 
-The `brik64-core` crate brings all 128 monomers (64 core + 64 extended) and EVA algebra operators to native Rust. Use saturating arithmetic, verified crypto, and composable pipelines directly in your Rust code. No PCD files, no compiler invocation.
+The Rust skill covers BRIK64-oriented operation patterns and historical SDK
+usage notes for Rust projects. Check current docs before installing packages or
+making SDK availability claims.
 
 Install when: you are working in a Rust project and want BRIK64 operation
 patterns without adopting PCD.
@@ -98,7 +98,9 @@ patterns without adopting PCD.
 ### `brik64-javascript`
 **Use @brik64/core in JavaScript / TypeScript — no public CLI needed.**
 
-The `@brik64/core` npm package brings 128 monomers (64 core + 64 extended) to Node.js and browsers. Works with Web Crypto API. Full EVA algebra pipeline composition in TypeScript.
+The JavaScript skill covers BRIK64-oriented operation patterns and historical
+SDK usage notes for JavaScript and TypeScript projects. Check current docs
+before installing packages or making SDK availability claims.
 
 Install when: you are working in a JS/TS project and want Digital Circuitality properties without adopting PCD.
 
@@ -107,7 +109,9 @@ Install when: you are working in a JS/TS project and want Digital Circuitality p
 ### `brik64-python`
 **Use brik64 in Python — no public CLI needed.**
 
-The `brik64` PyPI package brings 128 monomers (64 core + 64 extended) to Python 3.10+. Identical semantics to the Rust and JS versions. Pipeline composition via `eva.pipeline()`.
+The Python skill covers BRIK64-oriented operation patterns and historical SDK
+usage notes for Python projects. Check current docs before installing packages
+or making SDK availability claims.
 
 Install when: you are working in a Python project and want BRIK64 operation
 patterns without adopting PCD.
@@ -129,48 +133,20 @@ patterns without adopting PCD.
 
 ---
 
-## MCP Architecture (Minimalist)
+## Public Standards In Preparation
 
-The BRIK-64 MCP server follows 2026 best practices: **2 tools, not 10.**
+BRIK64 needs dedicated public standards for:
 
-| Tool | Type | Purpose |
-|------|------|--------|
-| `brik64.discover` | Read-only | Search, compare, compatibility, lineage — all server-side |
-| `brik64.execute` | Write | Compose, register, publish, acquire, export compliance |
+- PCD 1.0: the public Polymer Circuit Description format.
+- `.skill` 1.0: the public agent-skill package/instruction format.
 
-**~800 tokens** total schema (vs 12K+ for 10 tools). Preserves **98% of context window** for reasoning.
+Until those standards are published in dedicated repos and docs, use the current
+`brik64` skill plus https://docs.brik64.com as the active public guidance. Keep
+platform integrations, domain-system drafts, extended-operation drafts, and
+older major-version notes out of current public release instructions until they
+are published as versioned docs and repos.
 
-Procedural knowledge lives in **skills** loaded on-demand, not in tool schemas.
-
----
-
-## v5.0 Features
-
-BRIK-64 v5.0.0-beta.1 introduces the **Domain Declaration System** — compile-time domain verification for every value in a PCD program.
-
-- **Domain declarations:** Annotate variables with their valid ranges using `domain` blocks. The compiler proves at compile time that values stay within declared domains, eliminating an entire class of runtime errors.
-- **Function parameter domains:** Function signatures now accept `domain` annotations on parameters, enabling callers and callees to share verified contracts without runtime checks.
-- **Compile-time warnings:** `brik64` emits warnings when domain narrowing occurs implicitly (e.g., passing a wider domain into a narrower parameter), giving developers visibility into potential precision loss before code ships.
-- **Test suite:** 15,424 tests across all backends (native, Rust, JS, Python, WASM).
-
----
-
-## Extended Monomer Families (v4.0.0-beta.2+)
-
-In addition to the 64 core monomers (F0–F7, Φ_c = 1), BRIK-64 now includes 64 extended monomers across 8 new families. Extended monomers operate under **CONTRACT closure (Φ_c = CONTRACT)** — they interact with external systems and require runtime contracts rather than static proofs.
-
-| Family | Range | Operations |
-|--------|-------|------------|
-| F8: Float64 | MC_64–MC_71 | FADD, FSUB, FMUL, FDIV, FABS, FNEG, FSQRT, FMOD |
-| F9: Math | MC_72–MC_79 | SIN, COS, TAN, EXP, LN, LOG2, POW, CEIL |
-| F10: Network | MC_80–MC_87 | TCP_CONN, TCP_SEND, TCP_RECV, TCP_CLOSE, UDP_SEND, UDP_RECV, DNS_RESOLVE, HTTP_REQ |
-| F11: Graphics | MC_88–MC_95 | FB_CREATE, FB_SET_PX, FB_GET_PX, FB_CLEAR, FB_BLIT, FB_LINE, FB_RECT, FB_DIMS |
-| F12: Audio | MC_96–MC_103 | AUD_CREATE, AUD_WRITE, AUD_READ, AUD_MIX, AUD_GAIN, AUD_LEN, AUD_RATE, AUD_CHANS |
-| F13: Filesystem+ | MC_104–MC_111 | FS_STAT, FS_MKDIR, FS_RMDIR, FS_DELETE, FS_RENAME, FS_LIST, FS_EXISTS, FS_COPY |
-| F14: Concurrency | MC_112–MC_119 | SPAWN, JOIN, CHAN_NEW, CHAN_SEND, CHAN_RECV, MUTEX_NEW, MUTEX_LOCK, MUTEX_UNLOCK |
-| F15: Interop/FFI | MC_120–MC_127 | JSON_ENCODE, JSON_DECODE, FFI_CALL, FFI_LOAD, FFI_FREE, WASM_LOAD, WASM_CALL, WASM_FREE |
-
-All language SDKs (Rust, JavaScript, Python) expose extended monomers in v4.0.0-beta.2+.
+Planning checklist: [`standards/README.md`](standards/README.md).
 
 ---
 

--- a/skills/brik64-javascript/SKILL.md
+++ b/skills/brik64-javascript/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: brik64-javascript
-description: "Use the brik64 npm package (v4.0.0-beta.1) to install the public brik64 CLI or apply Digital Circuitality in JavaScript/TypeScript projects. Covers installation, all 128 monomers (64 core + 64 extended), EVA composition, async patterns, Node.js and browser usage. Wrapping arithmetic. Use when writing JS/TS code with BRIK-64 libraries."
-version: 4.0.0-beta.1
+description: "Historical JavaScript/TypeScript Digital Circuitality patterns for BRIK64 work. Check docs.brik64.com and the current public brik64 skill before installing packages or making SDK, certification, catalog, or extended-operation claims."
+version: 0.1.0-beta.2-public-reference
 ---
 
 # BRIK-64 for JavaScript / TypeScript
 
-Apply Digital Circuitality in your JavaScript and TypeScript projects.
+Apply Digital Circuitality patterns in JavaScript and TypeScript projects.
+Check https://docs.brik64.com and the current `brik64` skill before presenting
+package availability, SDK exports, or CLI behavior as current public truth.
 
 **Docs:** https://docs.brik64.com
 **Package:** https://www.npmjs.com/package/brik64
@@ -16,17 +18,16 @@ Apply Digital Circuitality in your JavaScript and TypeScript projects.
 ## Installation
 
 ```bash
-# Install CLI + SDK
-npm install -g brik64
-# pnpm add -g brik64
-# yarn global add brik64
+# Current public CLI beta
+npm install -g @brik64/cli@beta
+brik --version
 
-# Or use as a project dependency
-npm install brik64
-npx brik64 --version
+# Historical SDK examples below may reference older packages or APIs.
+# Verify current package availability before using them in public instructions.
 ```
 
-Works in **Node.js** (≥ 16). Downloads native binary for your platform on postinstall.
+Do not assume native binary download behavior unless the current package proves
+it.
 
 ---
 
@@ -45,9 +46,11 @@ import { mc, eva } from 'https://cdn.brik64.dev/sdk/v2/index.js';
 
 ---
 
-## 128 Monomers (64 core + 64 extended)
+## Historical SDK Operation Patterns
 
-The SDK exports all 128 monomers across 8 families (core) plus 8 extended families.
+The examples below are design patterns for bounded operations. Treat package
+exports and operation names as historical reference unless current docs confirm
+them.
 
 ## Arithmetic (wrapping — never throws, wraps at 256)
 
@@ -192,21 +195,21 @@ function safeParse(json: string): { ok: true; data: unknown } | { ok: false; err
 
 ## Important Distinction
 
-Using `brik64` applies Digital Circuitality **as a methodology** in your JS/TS code:
+Using these patterns applies Digital Circuitality **as a methodology** in your
+JS/TS code:
 
 - ✅ Saturating arithmetic (no overflow bugs in bitwise operations)
-- ✅ Formally specified crypto operations
-- ✅ EVA composition patterns
+- ✅ explicit crypto operation boundaries
+- ✅ composition patterns
 - ✅ Better code structure and determinism
 
 It does **not** give you:
 
-- ❌ CMF verification (Φ_c computation)
-- ❌ Auto-generated test suites from formal proof
-- ❌ Registry certification badge
+- CMF verification claims
+- auto-generated proof/test claims
+- catalog or certification badge claims
 
-For formal certification → write in PCD and compile to JS: `brik64 compile src/main.pcd --target js --emit-tests`
-→ https://docs.brik64.com/pcd/tutorial
+For PCD guidance, use the current `brik64` skill and docs.brik64.com.
 
 ---
 
@@ -221,8 +224,8 @@ This is what makes Φ_c = 1 possible.
 - **Bounded**: predicate on finite domain (e.g., even numbers in [0,100])
 - **Product**: cartesian product for multi-input operations
 
-Without bounded domains, the circuit is open and cannot be certified.
-The domain IS the circuit boundary.
+Without bounded domains, the design remains open-ended. Treat domain notes here
+as methodology guidance, not as a public certification claim.
 
 ### You Are the Circuit Designer
 
@@ -231,7 +234,8 @@ The programmer defines domain bounds based on their problem context:
 - Banking: transaction amount `[0.01, 1000000]`, account balance `[0, MAX_I64]`
 - Temperature sensor: reading `[-273, 1000]` °C (absolute zero to furnace)
 
-If a result falls outside the declared domain, the circuit does not close (Φ_c ≠ 1) and the program does not compile. This is not a bug — it is physics.
+If a result falls outside the intended domain, the design needs a tighter
+boundary or an explicit fallback.
 
 **Normal software:** calculates velocity = 100,000 km/s, stores it, crashes later.
 **Digital Circuitality:** the program does not compile. The circuit is open.
@@ -245,9 +249,11 @@ Domains are numeric ranges, not physical units. Precision depends on monomer cho
 
 Choose the right type for each calculation. If the result exceeds the range, the circuit doesn't close.
 
-## Extended Monomers (MC_64–MC_127) — v4.0.0-beta.1+
+## Historical Extended Operation Notes
 
-Extended monomers add 64 new operations across 8 families: Float64, Math, Network, Graphics, Audio, Filesystem+, Concurrency, and Interop/FFI. They operate under **CONTRACT closure (Φ_c = CONTRACT)** rather than static Coq proofs.
+Older drafts referenced extended operation families. Treat those notes as
+roadmap or historical material unless a current public release and docs page
+publish the exact SDK surface.
 
 ### Float64 & Math
 
@@ -282,4 +288,5 @@ const json = mc.interop.jsonEncode(value);
 const obj  = mc.interop.jsonDecode('{"key": 42}');
 ```
 
-> **Note:** Core monomers (MC_00–MC_63) have Φ_c = 1 (Coq-proven). Extended monomers (MC_64–MC_127) use Φ_c = CONTRACT — runtime contracts enforce correctness for external-facing operations.
+> Current public agent guidance lives in the `brik64` skill and
+> https://docs.brik64.com.

--- a/skills/brik64-python/SKILL.md
+++ b/skills/brik64-python/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: brik64-python
-description: "Use the brik64 Python package (v4.0.0-beta.1) to apply Digital Circuitality in Python projects. Covers installation, all 128 monomers (64 core + 64 extended), EVA composition, and integration patterns. Wrapping arithmetic. Use when writing Python code with BRIK-64 libraries."
-version: 4.0.0-beta.1
+description: "Historical Python Digital Circuitality patterns for BRIK64 work. Check docs.brik64.com and the current public brik64 skill before installing packages or making SDK, certification, catalog, or extended-operation claims."
+version: 0.1.0-beta.2-public-reference
 ---
 
 # BRIK-64 for Python
 
-Apply Digital Circuitality in your Python projects.
+Apply Digital Circuitality patterns in Python projects. Check
+https://docs.brik64.com and the current `brik64` skill before presenting package
+availability, SDK exports, or CLI behavior as current public truth.
 
 **Docs:** https://docs.brik64.com/installation
 **Package:** https://pypi.org/project/brik64/
@@ -16,12 +18,16 @@ Apply Digital Circuitality in your Python projects.
 ## Installation
 
 ```bash
-pip install brik64
-# uv add brik64
-# poetry add brik64
+# Current public CLI beta
+npm install -g @brik64/cli@beta
+brik --version
+
+# Historical SDK examples below may reference older packages or APIs.
+# Verify current package availability before using them in public instructions.
 ```
 
-Python 3.10+. Zero dependencies.
+Do not assume dependency or runtime behavior unless the current package proves
+it.
 
 ---
 
@@ -36,9 +42,11 @@ from brik64.eva import seq, par, cond, pipeline
 
 ---
 
-## 128 Monomers (64 core + 64 extended)
+## Historical SDK Operation Patterns
 
-The SDK exports all 128 monomers across 8 families (core) plus 8 extended families.
+The examples below are design patterns for bounded operations. Treat package
+exports and operation names as historical reference unless current docs confirm
+them.
 
 ## Arithmetic (wrapping — never raises, wraps at 256)
 
@@ -181,12 +189,11 @@ Using `brik64` applies Digital Circuitality **as a methodology** in your Python 
 
 It does **not** give you:
 
-- ❌ CMF verification (Φ_c)
-- ❌ Auto-generated test suites
-- ❌ Registry certification
+- CMF verification claims
+- auto-generated proof/test claims
+- catalog or certification badge claims
 
-For formal certification → write in PCD and compile to Python: `brik64 compile src/main.pcd --target py --emit-tests`
-→ https://docs.brik64.com/pcd/tutorial
+For PCD guidance, use the current `brik64` skill and docs.brik64.com.
 
 ---
 
@@ -201,8 +208,8 @@ This is what makes Φ_c = 1 possible.
 - **Bounded**: predicate on finite domain (e.g., even numbers in [0,100])
 - **Product**: cartesian product for multi-input operations
 
-Without bounded domains, the circuit is open and cannot be certified.
-The domain IS the circuit boundary.
+Without bounded domains, the design remains open-ended. Treat domain notes here
+as methodology guidance, not as a public certification claim.
 
 ### You Are the Circuit Designer
 
@@ -211,7 +218,8 @@ The programmer defines domain bounds based on their problem context:
 - Banking: transaction amount `[0.01, 1000000]`, account balance `[0, MAX_I64]`
 - Temperature sensor: reading `[-273, 1000]` °C (absolute zero to furnace)
 
-If a result falls outside the declared domain, the circuit does not close (Φ_c ≠ 1) and the program does not compile. This is not a bug — it is physics.
+If a result falls outside the intended domain, the design needs a tighter
+boundary or an explicit fallback.
 
 **Normal software:** calculates velocity = 100,000 km/s, stores it, crashes later.
 **Digital Circuitality:** the program does not compile. The circuit is open.
@@ -225,9 +233,11 @@ Domains are numeric ranges, not physical units. Precision depends on monomer cho
 
 Choose the right type for each calculation. If the result exceeds the range, the circuit doesn't close.
 
-## Extended Monomers (MC_64–MC_127) — v4.0.0-beta.1+
+## Historical Extended Operation Notes
 
-Extended monomers add 64 new operations across 8 families: Float64, Math, Network, Graphics, Audio, Filesystem+, Concurrency, and Interop/FFI. They operate under **CONTRACT closure (Φ_c = CONTRACT)** rather than static Coq proofs.
+Older drafts referenced extended operation families. Treat those notes as
+roadmap or historical material unless a current public release and docs page
+publish the exact SDK surface.
 
 ### Float64 & Math
 
@@ -265,4 +275,5 @@ json_str = interop.json_encode(value)
 obj      = interop.json_decode('{"key": 42}')
 ```
 
-> **Note:** Core monomers (MC_00–MC_63) have Φ_c = 1 (Coq-proven). Extended monomers (MC_64–MC_127) use Φ_c = CONTRACT — runtime contracts enforce correctness for external-facing operations.
+> Current public agent guidance lives in the `brik64` skill and
+> https://docs.brik64.com.

--- a/skills/brik64-rust/SKILL.md
+++ b/skills/brik64-rust/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: brik64-rust
-description: "Use the brik64 Rust crate (v4.0.0-beta.1) to apply Digital Circuitality in Rust projects. Covers installation, all 128 monomers (64 core + 64 extended), EVA composition, integration patterns, and the methodology vs. certification distinction. Wrapping arithmetic. Use when writing Rust code with BRIK-64 libraries."
-version: 4.0.0-beta.1
+description: "Historical Rust Digital Circuitality patterns for BRIK64 work. Check docs.brik64.com and the current public brik64 skill before installing crates or making SDK, certification, catalog, or extended-operation claims."
+version: 0.1.0-beta.2-public-reference
 ---
 
 # BRIK-64 for Rust
 
-Apply Digital Circuitality inside your existing Rust projects using the `brik64` crate.
+Apply Digital Circuitality patterns inside Rust projects. Check
+https://docs.brik64.com and the current `brik64` skill before presenting crate
+availability, SDK exports, or CLI behavior as current public truth.
 
 **Docs:** https://docs.brik64.com
 **Crate:** https://crates.io/crates/brik64
@@ -17,16 +19,17 @@ Apply Digital Circuitality inside your existing Rust projects using the `brik64`
 
 ```toml
 [dependencies]
-brik64 = "4.0.0-beta.1"
+# Historical SDK examples below may reference older packages or APIs.
+# Verify current crate availability before using them in public instructions.
 ```
 
 Or via CLI:
 ```bash
-cargo add brik64
+brik --version
 ```
 
 ```bash
-cargo add brik64
+npm install -g @brik64/cli@beta
 ```
 
 ---
@@ -53,9 +56,11 @@ use brik64::{mc, eva};
 
 ---
 
-## 128 Monomers (64 core + 64 extended)
+## Historical SDK Operation Patterns
 
-The crate exports all 128 monomers across 8 families (core) plus 8 extended families.
+The examples below are design patterns for bounded operations. Treat package
+exports and operation names as historical reference unless current docs confirm
+them.
 
 ## Arithmetic (wrapping — never panics, wraps at 256)
 
@@ -216,18 +221,18 @@ fn process(input: &str) -> Result<String, String> {
 Using `brik64` applies Digital Circuitality **as a methodology** inside your Rust code. This gives you:
 
 - ✅ Saturating arithmetic (no panics, no overflow)
-- ✅ Formally specified crypto operations
-- ✅ EVA composition patterns
+- ✅ explicit crypto operation boundaries
+- ✅ composition patterns
 - ✅ Better code structure and determinism
 
 It does **not** give you:
 
-- ❌ CMF verification (Φ_c computation)
-- ❌ Auto-generated test suites from formal proof
-- ❌ Registry certification badge
-- ❌ Φ_c = 1 compiler enforcement
+- CMF verification claims
+- auto-generated proof/test claims
+- catalog or certification badge claims
+- compiler-enforced closure claims
 
-For formal certification → write in PCD: https://docs.brik64.com/pcd/tutorial
+For PCD guidance, use the current `brik64` skill and docs.brik64.com.
 
 ---
 
@@ -242,8 +247,8 @@ This is what makes Φ_c = 1 possible.
 - **Bounded**: predicate on finite domain (e.g., even numbers in [0,100])
 - **Product**: cartesian product for multi-input operations
 
-Without bounded domains, the circuit is open and cannot be certified.
-The domain IS the circuit boundary.
+Without bounded domains, the design remains open-ended. Treat domain notes here
+as methodology guidance, not as a public certification claim.
 
 ### You Are the Circuit Designer
 
@@ -252,7 +257,8 @@ The programmer defines domain bounds based on their problem context:
 - Banking: transaction amount `[0.01, 1000000]`, account balance `[0, MAX_I64]`
 - Temperature sensor: reading `[-273, 1000]` °C (absolute zero to furnace)
 
-If a result falls outside the declared domain, the circuit does not close (Φ_c ≠ 1) and the program does not compile. This is not a bug — it is physics.
+If a result falls outside the intended domain, the design needs a tighter
+boundary or an explicit fallback.
 
 **Normal software:** calculates velocity = 100,000 km/s, stores it, crashes later.
 **Digital Circuitality:** the program does not compile. The circuit is open.
@@ -266,9 +272,11 @@ Domains are numeric ranges, not physical units. Precision depends on monomer cho
 
 Choose the right type for each calculation. If the result exceeds the range, the circuit doesn't close.
 
-## Extended Monomers (MC_64–MC_127) — v4.0.0-beta.1+
+## Historical Extended Operation Notes
 
-Extended monomers add 64 new operations across 8 families: Float64, Math, Network, Graphics, Audio, Filesystem+, Concurrency, and Interop/FFI. They operate under **CONTRACT closure (Φ_c = CONTRACT)** rather than static Coq proofs.
+Older drafts referenced extended operation families. Treat those notes as
+roadmap or historical material unless a current public release and docs page
+publish the exact SDK surface.
 
 ### Float64 & Math
 
@@ -306,4 +314,5 @@ let json = interop::json_encode(value);
 let obj  = interop::json_decode(r#"{"key": 42}"#);
 ```
 
-> **Note:** Core monomers (MC_00–MC_63) have Φ_c = 1 (Coq-proven). Extended monomers (MC_64–MC_127) use Φ_c = CONTRACT — runtime contracts enforce correctness for external-facing operations.
+> Current public agent guidance lives in the `brik64` skill and
+> https://docs.brik64.com.

--- a/skills/digital-circuitality/SKILL.md
+++ b/skills/digital-circuitality/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: digital-circuitality
-description: "Teaches the Digital Circuitality methodology — how to think and design programs as closed circuits in ANY language (Rust, Python, JS, Go...). No PCD or public CLI required. Use when designing software with circuit thinking, applying monomer-based operations, or structuring programs for maximum determinism and correctness."
+description: "Teaches the Digital Circuitality methodology — how to think and design programs as bounded, inspectable circuits in any language. No PCD or public CLI required. Check the current brik64 skill and docs.brik64.com before making CLI, SDK, catalog, certification, or formal-proof claims."
 ---
 
 # Digital Circuitality — Circuit Thinking for Any Language
 
-Apply the engineering discipline of Digital Circuitality to your code — regardless of language. This skill transforms how you design programs: from open, unbounded systems to closed, deterministic circuits.
+Apply the engineering discipline of Digital Circuitality to your code regardless
+of language. This skill is methodology guidance: it helps agents design bounded,
+inspectable logic. It is not itself a certification surface.
 
 **Full reference:** https://docs.brik64.com/theory/digital-circuitality
 
@@ -23,7 +25,7 @@ Hardware engineer designs:      You design:
 Logic gate (NAND, AND, OR)  →   Monomer (add8, hash, concat)
 Circuit board               →   Function (polymer)
 Signal integrity            →   Φ_c = 1 (circuit closed)
-Spec-driven, proof-checked  →   Deterministic, bounded, complete
+Spec-driven review          →   Deterministic, bounded, inspectable
 ```
 
 ---
@@ -130,31 +132,40 @@ A function is a **closed circuit** when:
 
 ---
 
-## The Lifter: On-Ramp for Existing Projects
+## Public Beta Boundary
 
-You don't need to rewrite your codebase to adopt Digital Circuitality. The **BRIK-64 Lifter** reverse-compiles existing source code into PCD:
+Current public agent guidance lives in the `brik64` skill and
+https://docs.brik64.com. Do not present lifter, multi-target compilation,
+distribution catalog, formal certification, or SDK package behavior as current public
+capabilities unless current release evidence supports the exact statement.
+
+Use this skill for design review and code-structure discipline. Use the
+`brik64` skill for current CLI workflows.
+
+## Historical Lifter Notes
+
+Older drafts described a source-to-PCD lifter workflow:
 
 ```bash
-brik64 lift app.ts       # TypeScript → PCD
-brik64 lift main.py      # Python → PCD
-brik64 lift lib.rs       # Rust → PCD
-brik64 lift main.go      # Go → PCD
-brik64 lift main.c       # C/C++ → PCD
-brik64 lift report.cbl   # COBOL → PCD
+brik lift app.ts
+brik lift main.py
+brik lift lib.rs
 ```
 
-**Pipeline: any language → PCD → any language.** Lift your code, certify it, then emit to any target.
+Treat these as roadmap/reference notes until the current public CLI and docs
+publish the exact commands.
 
-### Two-Tier Certification
+### Historical Closure Language
 
 | Tier | Condition | Meaning |
 |------|-----------|---------|
-| **CORE** | Phi_c = 1 | Full circuit closure — all paths deterministic |
-| **CONTRACT** | Phi_c = CONTRACT | Closure within declared contract boundaries |
+| **Core closure** | bounded local logic | deterministic review target |
+| **Contract boundary** | external dependency | explicit runtime assumption |
 
-## The 128 Core + Extended Operations
+## Operation Families As Design Vocabulary
 
-BRIK-64 defines 128 formally verified atomic operations (64 core + 64 extended) — the circuit components. Even without using the library, **model your design after these operations**:
+Use operation families as a vocabulary for design review. Do not treat this
+table as the current public SDK catalog or a formal-proof claim.
 
 | Family | Operations | Circuit Design Principle |
 |--------|-----------|--------------------------|
@@ -167,30 +178,14 @@ BRIK-64 defines 128 formally verified atomic operations (64 core + 64 extended) 
 | F6: Crypto | hash, hmac, aes_enc, aes_dec, sha256, rand, sign, verify | Typed inputs/outputs, no silent failures |
 | F7: System | time, sleep, env, exit, pid, signal, mmap, sysinfo | Explicit system calls, typed results |
 
-### Extended Families (Φ_c = CONTRACT)
+### External Operation Families
 
-In v4.0.0-beta.1, BRIK-64 adds 64 extended monomers (MC_64–MC_127) across 8 new families that interact with external systems. These operate under **CONTRACT closure** — runtime contracts enforce correctness rather than static proofs, since external I/O cannot be statically verified.
-
-| Family | Operations | Circuit Design Principle |
-|--------|-----------|--------------------------|
-| F8: Float64 | FADD, FSUB, FMUL, FDIV, FABS, FNEG, FSQRT, FMOD | IEEE 754 — defined behavior for NaN/Inf |
-| F9: Math | SIN, COS, TAN, EXP, LN, LOG2, POW, CEIL | Bounded transcendentals, defined domain |
-| F10: Network | TCP_CONN, TCP_SEND, TCP_RECV, TCP_CLOSE, UDP_*, DNS, HTTP | Explicit handles, paired connect/close |
-| F11: Graphics | FB_CREATE, FB_SET_PX, FB_GET_PX, FB_CLEAR, FB_BLIT, FB_LINE, FB_RECT, FB_DIMS | Bounded framebuffers, explicit lifecycle |
-| F12: Audio | AUD_CREATE, AUD_WRITE, AUD_READ, AUD_MIX, AUD_GAIN, AUD_LEN, AUD_RATE, AUD_CHANS | Typed buffers, explicit sample rates |
-| F13: Filesystem+ | FS_STAT, FS_MKDIR, FS_RMDIR, FS_DELETE, FS_RENAME, FS_LIST, FS_EXISTS, FS_COPY | Explicit existence checks, typed results |
-| F14: Concurrency | SPAWN, JOIN, CHAN_NEW, CHAN_SEND, CHAN_RECV, MUTEX_NEW, MUTEX_LOCK, MUTEX_UNLOCK | Structured concurrency, paired lock/unlock |
-| F15: Interop/FFI | JSON_ENCODE, JSON_DECODE, FFI_CALL, FFI_LOAD, FFI_FREE, WASM_LOAD, WASM_CALL, WASM_FREE | Explicit load/free lifecycle |
+External operations such as filesystem, network, graphics, audio, concurrency,
+and interop need explicit contracts. In public writing, describe them as
+contract-bound design areas unless a current standard or release publishes a
+stronger statement.
 
 The same circuit thinking applies: bound your domains, pair your resources, handle all branches.
-
-Install the libraries to use these operations with formal guarantees:
-
-```bash
-cargo add brik64          # Rust — v4.0.0-beta.1, 128 monomers, wrapping arithmetic
-npm install brik64        # JavaScript/TypeScript — v4.0.0-beta.1
-pip install brik64        # Python — v4.0.0-beta.1
-```
 
 ---
 
@@ -303,8 +298,8 @@ This is what makes Φ_c = 1 possible.
 - **Bounded**: predicate on finite domain (e.g., even numbers in [0,100])
 - **Product**: cartesian product for multi-input operations
 
-Without bounded domains, the circuit is open and cannot be certified.
-The domain IS the circuit boundary.
+Without bounded domains, the design remains open-ended. The domain is the
+design boundary.
 
 ### You Are the Circuit Designer
 
@@ -313,7 +308,8 @@ The programmer defines domain bounds based on their problem context:
 - Banking: transaction amount `[0.01, 1000000]`, account balance `[0, MAX_I64]`
 - Temperature sensor: reading `[-273, 1000]` °C (absolute zero to furnace)
 
-If a result falls outside the declared domain, the circuit does not close (Φ_c ≠ 1) and the program does not compile. This is not a bug — it is physics.
+If a result falls outside the intended domain, the design needs a tighter
+boundary or an explicit fallback.
 
 **Normal software:** calculates velocity = 100,000 km/s, stores it, crashes later.
 **Digital Circuitality:** the program does not compile. The circuit is open.
@@ -321,15 +317,16 @@ If a result falls outside the declared domain, the circuit does not close (Φ_c 
 ### Precision Engineering
 
 Domains are numeric ranges, not physical units. Precision depends on monomer choice:
-- **U8/I64 (core):** exact integer arithmetic, no rounding, Φ_c = 1
-- **F64 (extended):** IEEE 754 floats, has rounding errors, Φ_c = CONTRACT
+- **Integer arithmetic:** exact within declared bounds
+- **Float arithmetic:** requires explicit rounding and NaN/Inf handling
 - **Fixed-point pattern:** scale to integers (3.14 → 3140), compute exactly, scale back
 
 Choose the right type for each calculation. If the result exceeds the range, the circuit doesn't close.
 
-### Certified Math at Any Precision
+### Fixed-Point Math Pattern
 
-Any mathematical function — logarithms, trigonometry, square roots — can be implemented as a certified polymer (Φ_c = 1) using only core monomers with scaled integers.
+Mathematical functions can often be represented with fixed-point patterns when
+precision is declared explicitly.
 
 The designer declares the precision:
 ```
@@ -340,20 +337,17 @@ domain pi_15: Range [3141592653589793, ...]; // π with 15 decimals
 
 Like choosing a 12-bit vs 16-bit ADC — the engineer decides the resolution. The "error" is not accidental IEEE 754 rounding. It's the precision you declared in your domain.
 
-**Result:** ln(), sin(), cos(), sqrt() — all certifiable. All deterministic. Same input → same output on every platform, every time.
+Result: precision becomes a visible engineering choice instead of an accidental
+runtime side effect.
 
-## Methodology vs. Formal Certification
+## Methodology vs. Product Evidence
 
-| | Digital Circuitality (this skill) | BRIK-64 Formal Certification |
+| | Digital Circuitality (this skill) | BRIK64 product evidence |
 |---|---|---|
-| **Language** | Any (Rust, Python, JS, Go...) | PCD only |
-| **Verification** | Your discipline + code review | Compiler-enforced (CMF) |
-| **Φ_c proof** | Not provable — design discipline | Mathematically proven |
-| **Test suite** | You write | Auto-generated by `brik64 --emit-tests` |
-| **Registry badge** | Not available | Published to BRIK-64 Registry |
-| **Value** | Better design, fewer bugs | Structural impossibility of logic errors |
+| **Language** | Any (Rust, Python, JS, Go...) | Current docs and release artifacts |
+| **Verification** | discipline + code review + tests | bounded CLI reports or evidence packs when available |
+| **Public claims** | methodology only | exact artifact/version scope |
+| **Value** | clearer boundaries and fewer hidden assumptions | traceable operational evidence |
 
-> **Use circuit thinking everywhere. Get formal proof through PCD.**
->
-> If you need formal certification (safety-critical systems, AI policy enforcement, compliance):
-> → [docs.brik64.com/pcd/tutorial](https://docs.brik64.com/pcd/tutorial)
+> Use circuit thinking everywhere. Use current BRIK64 docs and release evidence
+> when a public claim needs product support.

--- a/skills/pcd-system/SKILL.md
+++ b/skills/pcd-system/SKILL.md
@@ -1,275 +1,69 @@
 ---
 name: pcd-system
-description: Complete PCD language reference + brik64 CLI for BRIK-64 BETA 5.0.0-beta.1. Covers syntax, all 128 monomers (64 core + 64 extended), CMF debug, policy circuits, package manager, Lifter (12 languages, 100% liftability, SSA transform), two-tier certification (CORE + CONTRACT), and 13-target compilation. Use when writing .pcd files or using the public brik64 CLI.
+description: Current public-beta PCD reference notes for BRIK64 agents. Use alongside the current brik64 skill and docs.brik64.com. Keep older platform-integration, domain-system, extended-operation, multi-target, certification, and distribution-catalog material out of current public instructions unless a current public release explicitly supports it.
 triggers:
-  - writing PCD programs
-  - using brik64 CLI
-  - building AI safety policy circuits
-  - debugging CMF errors
-  - compiling to BIR/Rust/JS/TS/Python/C/C++/Go/COBOL/PHP/Java/Swift/WASM/native
-  - lifting source code to PCD
-  - managing PCD packages
-version: 5.0.0-beta.1
+  - writing PCD notes
+  - using brik CLI public beta
+  - reviewing PCD examples
+  - checking current docs before public claims
+version: 0.1.0-beta.2-public-reference
 ---
 
-# PCD System — BRIK-64 BETA 5.0.0-beta.1
+# PCD System — Public Beta Reference Notes
 
-Complete reference for writing PCD programs, using the public `brik64` CLI, and working with the BRIK-64 Registry platform.
+This skill contains current public-beta PCD orientation for agents. For current
+public agent operation, install and use the `brik64` skill first, then check
+https://docs.brik64.com before making release, command, or capability claims.
 
-`brik64` is the public CLI name. If your current alpha install still exposes
-`brikc`, treat it as a temporary compatibility shim and substitute it in the
-same commands below.
+Current public CLI command: `brik`.
+Current public package: `@brik64/cli@0.1.0-beta.2`.
+
+Current public surface:
+
+- `brik` CLI public beta
+- `.brik` local traceability metadata
+- PCD 1.0 working surface in preparation
+- agent workflows that point to docs.brik64.com
+
+Roadmap or non-current surface unless separately published:
+
+- platform integration servers
+- distribution catalogs
+- domain-system drafts
+- extended-operation drafts
+- multi-target compilation claims
+- formal certification claims
+- compiler-sovereignty or reproducibility claims
 
 ---
 
 ## Quick Start
 
 ```bash
-# Install brik64 (recommended)
-curl -fsSL https://brik64.dev/install | sh
-
-# Interactive banner (no args)
-brik64
-
-# Full pipeline: lift → check → build → execute
-brik64 lift app.ts                          # any language → PCD
-brik64 check program.pcd                    # validate circuit
-brik64 compile --input program.pcd --target bir --output program.bir  # build
-brik64 run program.pcd                      # execute via BIR
-
-# Lift source code to PCD (12 languages, 100% liftability)
-brik64 lift app.js          # JS, TS, TSX, JSX
-brik64 lift main.py         # Python
-brik64 lift lib.rs          # Rust
-brik64 lift main.c          # C, C++
-brik64 lift main.go         # Go
-brik64 lift report.cbl      # COBOL
-brik64 lift index.php       # PHP
-brik64 lift Main.java       # Java
-
-# Policy circuits (5 templates)
-brik64 policy new --template no_network      # no_network, no_filesystem, memory_bound, sandbox, allow_all
-brik64 policy verify policy.pcd
-brik64 policy list
-
-# Package manager
-brik64 pkg init                              # creates brik.toml
-brik64 pkg add some-package
-brik64 pkg publish                           # publish to registry.brik64.dev
-brik64 pkg deps                              # show dependency tree
-
-# Registry API
-# Live at registry.brik64.dev/v1
-
-# Or via pip
-pip install brik64
-
-# Verify
-brik64 --version
+npm install -g @brik64/cli@beta
+brik --version
+brik help
+brik init
+brik pcd generate order-risk
+brik skill diff --target AGENTS.md
 ```
 
-// Usage:
-let _ = println("Hello, World!");
-let _ = println(MC_40.CONCAT("Value: ", some_string));
-```
+## PCD Orientation
 
-Or import stdlib directly:
-```pcd
-import "stdlib/io.pcd";
-// then use println(s) directly
-```
+Treat PCD as a circuit description format for bounded logic. In public beta
+writing, describe it as a working surface in preparation, not as a completed
+public standard until `brik64/pcd-standard` and docs.brik64.com publish the
+versioned standard.
 
----
+Current agent posture:
 
-## The 128 Monomers — Verified Signatures (BETA 4.0.0-beta.2)
+- write small, inspectable PCD candidates;
+- keep input and output boundaries explicit;
+- avoid claiming certification from syntax, examples, or CLI output alone;
+- report exact CLI/runtime evidence when available;
+- link to docs.brik64.com for the current command surface.
 
-> **128 monomers = 64 core (MC_00–MC_63) + 64 extended (MC_64–MC_127)**
-> Core monomers are formally verified. Extended monomers provide higher-level operations.
-
-### ⚠️ CRITICAL: ADD8 and MUL8 are 8-bit (U8 wrapping, max 255)
-
-`MC_00.ADD8(250, 10)` → `4` (wraps at 256, NOT saturates)
-`MC_02.MUL8(99, 3)` → `41` (297 wraps: 297 % 256 = 41)
-
-**For 64-bit arithmetic, use PCD native operators: `+`, `-`, `*`, `/`**
-
-### Family 0: Arithmetic (MC_00–MC_07) — 8-bit WRAPPING
-
-| MC# | Name | Signature | Notes |
-|-----|------|-----------|-------|
-| MC_00 | ADD8 | (a:U8, b:U8) → U8 | **U8 WRAPPING** — use `+` for 64-bit |
-| MC_01 | SUB8 | (a:U8, b:U8) → U8 | **U8 WRAPPING** — use `-` for 64-bit |
-| MC_02 | MUL8 | (a:U8, b:U8) → U8 | **U8 WRAPPING** — use `*` for 64-bit |
-| MC_03 | DIV8 | (a:U8, b:U8) → Tuple(U8,U8) | Returns tuple: access with `qr[0]` (quotient), `qr[1]` (remainder) |
-| MC_04 | INC | (a:U8) → U8 | **1 arg only** — NOT MOD8(a,b) |
-| MC_05 | NEG/DEC | (a:U8) → U8 | **1 arg only** |
-| MC_06 | ABS8 | (a:I8) → U8 | Absolute value |
-| MC_07 | POW8 | (base:U8, exp:U8, mod:U8) → U8 | **3 args** — NOT 2 |
-
-> ⚠️ **DIV8 tuple access — verified syntax:**
-> ```pcd
-> let qr = MC_03.DIV8(a, b);
-> let q = qr[0];   // quotient
-> let r = qr[1];   // remainder
-> ```
-> The syntax `let (q, r) = MC_03.DIV8(a, b)` causes a **parse error** — do NOT use it.
-
-> ⚠️ **For modulo, use native PCD operator**: `let rem = a % b;`
-> The `%` operator works natively for 64-bit integers.
-
-### Family 1: Logic (MC_08–MC_15)
-
-| MC# | Name | Signature |
-|-----|------|-----------|
-| MC_08 | AND | (a:U8, b:U8) → U8 |
-| MC_09 | OR | (a:U8, b:U8) → U8 |
-| MC_10 | XOR | (a:U8, b:U8) → U8 |
-| MC_11 | NOT | (a:U8) → U8 |
-| MC_12 | NAND | (a:U8, b:U8) → U8 |
-| MC_13 | NOR | (a:U8, b:U8) → U8 |
-| MC_14 | XNOR | (a:U8, b:U8) → U8 |
-| MC_15 | BUF | (a:U8) → U8 |
-
-### Family 2: Memory (MC_16–MC_23)
-
-| MC# | Name | Signature |
-|-----|------|-----------|
-| MC_16 | ALLOC | (size:U64) → U64 (ptr) |
-| MC_17 | FREE | (ptr:U64) → Unit |
-| MC_18 | READ | (ptr:U64, offset:U64) → U8 |
-| MC_19 | WRITE_MEM | (ptr:U64, offset:U64, val:U8) → Unit |
-| MC_20 | COPY | (dst:U64, src:U64, len:U64) → Unit |
-| MC_21 | ZERO | (ptr:U64, len:U64) → Unit |
-| MC_22 | CMP_MEM | (a:U64, b:U64, len:U64) → I8 |
-| MC_23 | BOUNDS | (ptr:U64, size:U64, len:U64) → Bool |
-
-### Family 3: Control (MC_24–MC_31)
-
-> ⚠️ MC_24 IF is NOT a ternary function. Use PCD `if/else` syntax instead.
-
-| MC# | Name | Signature | Notes |
-|-----|------|-----------|-------|
-| MC_24 | IF | [Bool] → Unit | Low-level branch signal — use `if(cond){...}` syntax |
-| MC_25 | JUMP | [U64] → Unit | Low-level jump |
-| MC_26 | CALL | [U64] → Unit | Low-level call |
-| MC_27 | RET | [] → Unit | Low-level return |
-| MC_28 | HALT | [] → Unit | Halt execution |
-| MC_29 | NOP | [] → Unit | No-op |
-| MC_30 | CMP | (a:I64, b:I64) → I8 | Compare: -1/0/1 |
-| MC_31 | LOOP_CTRL | [Bool] → Unit | Loop control signal |
-
-### Family 4: I/O (MC_32–MC_39)
-
-| MC# | Name | Signature | Notes |
-|-----|------|-----------|-------|
-| MC_32 | READ_FD | (fd:U64) → U8 | Read byte from file descriptor |
-| MC_33 | WRITE_FD | (fd:U64, byte:U8) → Unit | Write byte to fd |
-| MC_34 | OPEN | (path:String, flags:U64) → U64 | Returns fd |
-| MC_35 | CLOSE | (fd:U64) → Unit | Close fd |
-| MC_36 | SEEK | (fd:U64, offset:I64, whence:U8) → I64 |
-| MC_37 | STAT | (path:String) → Array | File metadata |
-| MC_38 | MKDIR | (path:String) → Bool |
-| MC_39 | DELETE | (path:String) → Bool |
-
-### Family 5: String (MC_40–MC_47)
-
-| MC# | Name | Signature | Notes |
-|-----|------|-----------|-------|
-| MC_40 | CONCAT | (a:String, b:String) → String | ✅ verified |
-| MC_41 | SPLIT | (s:String, delim:String) → Array(String) | ✅ returns list; access with `parts[i]` |
-| MC_42 | SUBSTR | (s:String, start:U64, len:U64) → String | ✅ use for CHAR_AT |
-| MC_43 | LEN | (s:String|Array) → U64 | ✅ verified — works on String (byte length) AND Array (element count) |
-| MC_44 | UPPER | (s:String) → String | ✅ verified |
-| MC_45 | LOWER | (s:String) → String | ✅ verified — NOT CHAR_AT |
-| MC_46 | TRIM | (s:String) → String | ✅ verified |
-| MC_47 | MATCH | (s:String, pattern:String) → Bool | ✅ verified — uses regex; falls back to substring if invalid regex |
-
-> ⚠️ **CHAR_AT does not exist as a monomer.** Use `MC_42.SUBSTR(s, i, 1)` to get char at index i.
->
-> ✅ **MC_43.LEN works on String (byte length) and Array (element count).**
->
-> ⚠️ **MC_41.SPLIT returns a list.** Access elements with `parts[i]` (square bracket indexing), NOT `.get(i)`.
-
-### Family 6: Crypto (MC_48–MC_55)
-
-| MC# | Name | Signature | Notes |
-|-----|------|-----------|-------|
-| MC_48 | HASH | (data:String) → String | ⚠️ **NOT WRITE** — SHA-256 hash; **accepts String, returns hex String** |
-| MC_49 | HMAC | (key:Array(U8), data:Array(U8)) → Array(U8,32) |
-| MC_50 | ENCRYPT | (key:Array(U8,32), data:Array(U8)) → Array(U8) |
-| MC_51 | DECRYPT | (key:Array(U8,32), data:Array(U8)) → Array(U8) |
-| MC_52 | SIGN | (key:Array(U8,64), data:Array(U8)) → Array(U8,64) |
-| MC_53 | VERIFY_SIG | (key:Array(U8,32), sig:Array(U8,64), data:Array(U8)) → Bool |
-| MC_54 | RAND | (len:U64) → Array(U8) |
-| MC_55 | DERIVE | (seed:Array(U8), info:Array(U8)) → Array(U8,32) |
-
-> ⚠️ **MC_48.HASH runtime behavior (verified in beta.3):**
-> - Accepts: String (not Array(U8) as catalog says)
-> - Returns: hex String (e.g., `"ef0dd2a0..."`) — NOT Array(U8,32)
-> - Catalog signature `[Array(U8,0)]→Array(U8,32)` does NOT match runtime behavior
-
-### Family 7: System (MC_56–MC_63)
-
-| MC# | Name | Signature | Notes |
-|-----|------|-----------|-------|
-| MC_56 | GETPID | [] → U64 | ⚠️ **NOT STRLEN** — returns process id |
-| MC_57 | GETTIME | [] → U8 | ⚠️ **NOT SUBSTR** — returns time byte |
-| MC_58 | WRITE | (fd:U64, s:String, len:U64) → Unit | ⚠️ stdout = fd 1; catalog shows `[]→U64` but runtime accepts 3 args |
-| MC_59 | READ_STR | (fd:U64, len:U64) → String |
-| MC_60 | ARGS | [] → Array(String) | All CLI arguments |
-| MC_61 | EXIT | (code:U8) → Unit |
-| MC_62 | SLEEP | (ms:U64) → Unit |
-| MC_63 | ENV | (name:String) → String | ⚠️ Always returns String, not Int; in native ELF reads argv[1] |
-
-> ⚠️ **MC_58.WRITE verified pattern:**
-> ```pcd
-> MC_58.WRITE(1, "hello\n", 6);  // fd=1 is stdout
-> ```
->
-> ⚠️ **MC_63.ENV always returns String.** `MC_63.ENV("PORT")` returns `"8080"`, not `8080`.
-> To convert: use `to_int()` from `stdlib/string.pcd` or hardcode numeric values.
->
-> ⚠️ **MC_63.ENV in native ELF reads argv[1]** (command-line argument), NOT environment variable.
-> In BIR interpreter, reads actual environment variable.
-
----
-
-## Imports and stdlib
-
-```pcd
-import "stdlib/io.pcd";              // println, print, read_line
-import "stdlib/string.pcd";          // join, trim, replace, starts_with, char_at
-import "stdlib/math.pcd";            // min, max, abs, pow, sqrt, clamp, gcd, factorial
-import "stdlib/array.pcd";           // map, filter, reduce, sort, contains
-import "stdlib/fmt.pcd";             // format, pad_left, pad_right
-import "stdlib/json.pcd";            // parse, stringify
-import { println, print } from "stdlib/io.pcd";   // selective import
-import "mylib.pcd" as lib;            // alias import
-```
-
-Stdlib location on ECO: `~/brik64/software/examples/stdlib/`
-
----
-
-## CMF Error Reference
-
-CMF (Circuit Metric Failure) errors appear during `brik64 check` or `brik64 run`:
-
-| Code | Meaning | Fix |
-|------|---------|-----|
-| CMF-001x | Type mismatch | Check monomer signature — ensure types match |
-| CMF-002x | Arity error | Wrong number of arguments to monomer |
-| CMF-003x | Undefined variable | Declare with `let` before use |
-| CMF-004x | Φ_c < 1 | Circuit not closed — add `OUTPUT` statement |
-| CMF-005x | Import not found | Check path relative to .pcd file location |
-| CMF-006x | Circular import | Remove circular dependency |
-
-> `brik64 check` validates syntax and circuit structure but does NOT validate monomer arity.
-> Arity errors only appear at `brik64 run` (BIR interpreter) or compile time.
-
----
-
-## Policy Circuit Pattern (AI Safety)
+## Example Pattern
 
 ```pcd
 // ai-safety-policy.pcd — ALLOW/BLOCK guardrail
@@ -325,288 +119,34 @@ let result = if (check) { path_a(x) } else { path_b(x) };
 
 ---
 
-## brik64 CLI Reference — Verified Flags (4.0.0-beta.2)
+## CLI Boundary
+
+Use the current public command name in examples:
 
 ```bash
-# Compile to target
-brik64 compile --target bir program.pcd      # BIR bytecode (default)
-brik64 compile --target rust program.pcd     # Rust source
-brik64 compile --target js program.pcd       # JavaScript
-brik64 compile --target typescript program.pcd # TypeScript
-brik64 compile --target python program.pcd   # Python
-brik64 compile --target c program.pcd        # C
-brik64 compile --target cpp program.pcd      # C++
-brik64 compile --target go program.pcd       # Go
-brik64 compile --target cobol program.pcd    # COBOL
-brik64 compile --target php program.pcd      # PHP
-brik64 compile --target java program.pcd     # Java
-brik64 compile --target swift program.pcd    # Swift
-brik64 compile --target wasm program.pcd     # WASM
-brik64 compile --target native program.pcd   # ELF x86-64
-
-# Run directly
-brik64 run program.pcd                       # Compile + execute BIR
-
-# Check without compiling
-brik64 check program.pcd                     # Type check + CMF
-
-# Format
-brik64 fmt program.pcd                       # Format PCD source
-
-# REPL
-brik64 repl                                  # Interactive mode
-
-# Self-verify
-brik64 self-verify                           # Verify all 128 monomers
-
-# catalog — list monomers
-brik64 catalog list
-brik64 catalog show <N>
-
-# lift — reverse compile source to PCD (12 languages, SSA transform, 100% liftability)
-brik64 lift <file>            # JS, TS, TSX, JSX, Python, Rust, C, C++, Go, COBOL, PHP, Java
-brik64 lift app.tsx           # TSX/JSX supported
-# SSA transform: variable reassignment (total = total + x) → SSA form automatically
-# Two-tier certification: CORE (Phi_c=1) for core monomers, CONTRACT for extended
-
-# Full roundtrip: lift → check → build → execute
-brik64 lift calcPrice.js -o calcPrice.pcd
-brik64 check calcPrice.pcd
-brik64 build calcPrice.pcd -t python -o dist/
-python3 dist/calcPrice.py
-
-# policy — AI safety policy circuits
-brik64 policy new --template <TEMPLATE>   # no_network, no_filesystem, memory_bound, sandbox, allow_all
-brik64 policy verify <file.pcd>
-brik64 policy list
-
-# pkg — package manager
-brik64 pkg init               # creates brik.toml
-brik64 pkg add <package>
-brik64 pkg publish            # publishes to registry.brik64.dev
-brik64 pkg deps               # dependency tree
-
-# self-hosting
-brik64 self-host-status
-brik64 self-certify-pcd-cli   # verify PCD CLI fixed-point (gen1==gen2)
+brik --version
+brik help
+brik init
 ```
 
----
+When you need command details, check docs.brik64.com and the installed CLI
+itself. Do not copy older `brik64` command examples into public instructions
+unless the current release proves that exact command.
 
-## SDK Libraries (4.0.0-beta.1)
+## Standards Work Needed
 
-The CMF computes 7 metrics producing Φ_c (circuit closure):
+PCD 1.0 should be promoted into a dedicated public standard repository and docs
+section before this skill presents a complete grammar or normative catalog.
 
-| Metric | What it measures |
-|--------|------------------|
-| E_c | Computational energy (efficiency) |
-| H_d | Hamiltonian distance (optimality) |
-| S_d | Structural entropy (complexity) |
-| C_s | Cyclomatic stability (robustness) |
-| ETC | Entropic transfer coefficient (information flow) |
-| ΔN | Complexity deviation (overhead) |
-| Φ_c | Circuit closure — **1.0 = circuit is closed and correct** |
+Required public-standard artifacts:
 
-**Φ_c = 1 means:** all inputs consumed, all outputs produced, all paths verified.
+- `README.md`: human summary and current maturity label
+- `SPEC.md`: grammar, envelope, hashes, canonicalization, examples, and invalid cases
+- `VERSIONING.md`: compatibility rules and deprecation policy
+- `EXAMPLES.md`: minimal, realistic, tested examples
+- `NOTICE`: BRIK64 Inc. ownership and attribution
+- license or terms file appropriate for a public standard
+- agent-readable summary for tools that consume the standard
 
----
-
-## Policy Circuits (AI Guardrails)
-
-Policy circuits are PCD programs that verify AI agent actions and return ALLOW/BLOCK:
-
-```pcd
-fn policy_rate_limit(count: i64, window_ms: i64, max: i64) -> i64 {
-    let rate = div8(count, window_ms);
-    let q = rate[0];
-    return if (q > max) { 0 } else { 1 };
-}
-
-fn policy_budget(spent: i64, limit: i64) -> i64 {
-    let remaining = sub8(limit, spent);
-    return if (remaining > 0) { 1 } else { 0 };
-}
-
-fn policy_data_class(sensitivity: i64, dest_trust: i64) -> i64 {
-    return if (dest_trust < sensitivity) { 0 } else { 1 };
-}
-```
-
-Deploy as middleware:
-```bash
-# Python
-pip install brik64         # v4.0.0-beta.1 — 128 monomers (64 core + 64 extended)
-python3 -c "import brik64; print(dir(brik64.mc))"
-
-# npm / Node.js
-npm install brik64          # v4.0.0-beta.1 — 128 monomers, wrapping arithmetic
-npx brik64 --version
-
-# Rust
-cargo add brik64            # v4.0.0-beta.1 — 128 monomers, wrapping arithmetic
-```
-
-> All SDKs use **wrapping arithmetic** (not saturating) as of v4.0.0.
-
----
-
-## Installation (BETA 4.0.0-beta.2)
-
-```bash
-# Recommended — install script
-curl -fsSL https://brik64.dev/install | sh
-
-# npm
-npm install -g brik64
-
-# pip
-pip install brik64
-
-# Manual — Linux x86-64 (legacy artifact name during alpha transition)
-curl -L https://github.com/brik64/brik64-dist-releases/releases/download/beta-4.0.0-beta.2/brikc-beta-linux-x86_64 -o brik64 && chmod +x brik64
-
-# Manual — macOS Apple Silicon (M1/M2/M3/M4), legacy artifact name during alpha transition
-curl -L .../brikc-beta-macos-arm64 -o brik64 && chmod +x brik64
-xattr -d com.apple.quarantine brik64   # Remove macOS quarantine
-
-# Manual — macOS Intel, legacy artifact name during alpha transition
-curl -L .../brikc-beta-macos-intel -o brik64 && chmod +x brik64
-xattr -d com.apple.quarantine brik64
-```
-
-**Platform support in BETA 4.0.0-beta.2:**
-- ✅ Linux x86-64 (fully tested — ECO server)
-- ✅ macOS Apple Silicon (ARM64)
-- ✅ macOS Intel (x86-64)
-- ✅ Linux ARM64
-
----
-
-## Known BETA Limitations (beta.2)
-
-1. **ADD8/MUL8 are 8-bit wrapping** — Use native `+`, `*` for accumulation >255
-2. **DIV8 returns Tuple** — Access with `qr[0]`/`qr[1]`, NOT `let (q,r) = ...`
-3. **MC_43.LEN works on String and Array** — returns byte count for String, element count for Array
-4. **MC_48.HASH takes String** — NOT Array(U8); returns hex String NOT Array(U8,32)
-5. **native target generates ELF x86-64** — Not usable directly on macOS arm64
-6. **wasm32 target generates WAT text** — Needs wat2wasm to convert to binary
-7. **while loops broken in native ELF** — SSA bug; use `loop(N) { if(cond){...} }` instead
-8. **LSP protocol incomplete** — `brik64 lsp` starts but doesn't respond to JSON-RPC
-9. **ENV in native ELF reads argv[1]** — In BIR interpreter reads actual env var
-10. **Python backend**: variable `hex` renamed to `_brik_hex`; list indexing uses `[i]` not `.get(i)` (fixed beta.3)
-11. **JS backend**: generated code requires `node file.js` to produce output (fixed in beta.3 — adds `execute()` call)
-
----
-
-
-## Closure Domains
-
-Every monomer declares its domain — the bounded set of valid inputs and outputs.
-This is what makes Φ_c = 1 possible.
-
-- **Range**: `[0, 255]` for u8 operations
-- **Set**: `{true, false}` for boolean operations  
-- **Bounded**: predicate on finite domain (e.g., even numbers in [0,100])
-- **Product**: cartesian product for multi-input operations
-
-Without bounded domains, the circuit is open and cannot be certified.
-The domain IS the circuit boundary.
-
-### You Are the Circuit Designer
-
-The programmer defines domain bounds based on their problem context:
-- Flight computer: velocity `[0, 900]` km/h, altitude `[0, 15000]` m
-- Banking: transaction amount `[0.01, 1000000]`, account balance `[0, MAX_I64]`
-- Temperature sensor: reading `[-273, 1000]` °C (absolute zero to furnace)
-
-If a result falls outside the declared domain, the circuit does not close (Φ_c ≠ 1) and the program does not compile. This is not a bug — it is physics.
-
-**Normal software:** calculates velocity = 100,000 km/s, stores it, crashes later.
-**Digital Circuitality:** the program does not compile. The circuit is open.
-
-### Precision Engineering
-
-Domains are numeric ranges, not physical units. Precision depends on monomer choice:
-- **U8/I64 (core):** exact integer arithmetic, no rounding, Φ_c = 1
-- **F64 (extended):** IEEE 754 floats, has rounding errors, Φ_c = CONTRACT
-- **Fixed-point pattern:** scale to integers (3.14 → 3140), compute exactly, scale back
-
-Choose the right type for each calculation. If the result exceeds the range, the circuit doesn't close.
-
-## BRIK-64 Registry & MCP (Platform Layer)
-
-### What is the Registry?
-
-The Registry transforms BRIK-64 from a verification technology into a **platform of certified reusable software circuits**. Certified PCD polymers become discoverable, composable, licensable, and governable assets.
-
-**The monomers are the physics. The polymers are the product. The Registry is the market.**
-
-### MCP Server: 2-Tool Minimalist Architecture
-
-Following 2026 best practices (30 tools = confusion threshold, 100+ = guaranteed failure), the BRIK-64 MCP exposes **exactly 2 semantic tools** (~800 tokens) preserving 98% of context window.
-
-#### Tool 1: `brik64.discover` (read-only)
-
-All discovery operations in a single call. Server performs search, ranking, comparison, and compatibility check server-side.
-
-```json
-{
-  "intent": "Find a rate-limiting policy circuit for financial transactions",
-  "filters": {
-    "domain": "finance",
-    "criticality": "safety",
-    "license": "commercial"
-  },
-  "operations": ["search", "compare", "check_compatibility", "get_lineage"]
-}
-```
-
-#### Tool 2: `brik64.execute` (write operations)
-
-All state-changing operations in a single call.
-
-```json
-{
-  "action": "compose_and_register",
-  "inputs": ["asset://brik64/policy_rate_limit@1.2.0", "asset://brik64/policy_budget@1.0.3"],
-  "composition": "sequential",
-  "metadata": { "name": "financial_guardrail", "domain": "finance" }
-}
-```
-
-Actions: `compose_and_register`, `publish`, `acquire_license`, `export_compliance`, `deprecate`, `version`
-
-### Reuse Before Create Workflow
-
-```
-1. Interpret objective
-2. brik64.discover with intent + filters
-3. Evaluate ranked results (server-side)
-4. EXISTS? → brik64.execute { action: "acquire_license" }
-5. COMPOSE? → brik64.execute { action: "compose_and_register" }
-6. NOTHING? → Create from monomers, then register
-```
-
-### Inherited Certification
-
-If A (Φ_c=1) and B (Φ_c=1) are registered, then A ⊗ B is automatically certified — no new proofs needed. 1,000 circuits → millions of certified compositions.
-
-### Domain Packs
-
-1. AI Guardrails — rate limiting, budget, data classification, privilege
-2. Identity & Integrity — hashing, HMAC, signatures, provenance
-3. Enterprise Workflow — approvals, segregation of duties, SLA
-4. Financial Risk — spending controls, position limits, fraud rules
-5. DevSecOps — artifact verification, release gates, dependency approval
-6. Robotics — speed/force limits, geofencing, safe stop
-7. Medical Safety — dosage limits, contraindication checks
-8. Telecom — provisioning, routing policy, failover
-
-### API Endpoints
-
-| Domain | Key Endpoints |
-|--------|---------------|
-| Registry | `GET /assets`, `POST /search/advanced`, `GET /assets/{id}/lineage` |
-| Composition | `POST /compose`, `POST /compose/register` |
-| Marketplace | `GET /marketplace/listings`, `POST /marketplace/purchase` |
-| Audit | `GET /audit/events`, `GET /compliance/export` |
+Until then, this skill should orient agents and point them to docs, not define
+PCD 1.0 by itself.

--- a/standards/README.md
+++ b/standards/README.md
@@ -1,0 +1,61 @@
+# BRIK64 Public Standards Roadmap
+
+This repository hosts public agent skills. It does not replace the dedicated
+standard repositories that BRIK64 should publish for PCD 1.0 and `.skill` 1.0.
+
+Current maturity:
+
+- PCD 1.0: public standard in preparation.
+- `.skill` 1.0: public agent-instruction standard in preparation.
+- docs.brik64.com: primary public documentation surface.
+- `brik64/brik64-tools-skills`: current public skill source for agents.
+
+## Planned Repositories
+
+### `brik64/pcd-standard`
+
+Purpose: define the public Polymer Circuit Description format as a versioned
+standard.
+
+Required artifacts:
+
+- `README.md`: standard overview, maturity label, and docs links.
+- `SPEC.md`: syntax, envelopes, canonicalization, hashes, examples, and invalid cases.
+- `VERSIONING.md`: compatibility, deprecation, and migration policy.
+- `EXAMPLES.md`: tested minimal and realistic examples.
+- `NOTICE`: BRIK64 Inc. ownership and attribution.
+- `LICENSE` or terms file appropriate for a public standard.
+- `AGENTS.md`: agent-readable usage and claim boundary.
+
+### `brik64/skill-standard`
+
+Purpose: define the public `.skill` packaging and instruction format for AI
+agents consuming BRIK64 workflows.
+
+Required artifacts:
+
+- `README.md`: standard overview, maturity label, and docs links.
+- `SPEC.md`: file layout, metadata, triggers, versioning, and validation rules.
+- `VERSIONING.md`: compatibility, deprecation, and migration policy.
+- `EXAMPLES.md`: minimal skill, product skill, and claim-sensitive skill examples.
+- `NOTICE`: BRIK64 Inc. ownership and attribution.
+- `LICENSE` or terms file appropriate for a public standard.
+- `AGENTS.md`: agent-readable usage and claim boundary.
+
+## Publication Rule
+
+Do not present PCD 1.0 or `.skill` 1.0 as finalized public standards until:
+
+1. the dedicated repository exists;
+2. the standard has a versioned `SPEC.md`;
+3. docs.brik64.com links to the standard;
+4. examples and invalid cases are reviewed;
+5. public copy uses the same maturity label across docs, README files, and skills.
+
+## Public Boundary
+
+This roadmap is operational planning for public standards work. The active
+surface is the current public CLI beta, docs.brik64.com, and this skills repo.
+Platform integrations, distribution catalogs, and stronger certification
+surfaces need their own versioned release evidence before they appear in public
+instructions.


### PR DESCRIPTION
Summary
- Removes non-current v5/domain/extended/platform-integration language from public skill guidance.
- Reframes JS, Python, Rust, PCD, and Digital Circuitality skills as current beta guidance or historical design references.
- Adds standards roadmap for planned pcd-standard and skill-standard repositories.

Validation
- rg sensitive-term scan passed on the files in this PR.
- git diff --check passed.

Boundary
- Leaves unrelated untracked local AGENTIC_COMMERCE_POLICY.md out of the commit.