### PR TITLE
Align public skills for beta7

### DIFF
--- a/BETA7_SYNC.md
+++ b/BETA7_SYNC.md
@@ -1,0 +1,16 @@
+# BRIK64 Skills Beta7 Sync
+
+Date: 2026-06-05
+
+Aligned CLI: `0.1.0-beta.7`
+
+The public skill source is synchronized for the beta7 CLI release train.
+Installed copies should still verify live docs and the public release record
+before making drift-prone release claims.
+
+Current beta7 package coordinates:
+
+- CLI: `0.1.0-beta.7`
+- JS/TS SDK: `@brik64/core@0.1.0-beta.7`
+- Python SDK: `brik64==0.1.0b7`
+- Rust SDK: `brik64-core@0.1.0-beta.7`

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Public naming contract:
 - current public CLI command: `brik64`
 - compatibility CLI alias: `brik`
 - current public CLI install path: `curl -fsSL https://brik64.com/cli/install.sh | bash`
-- current JS/TS SDK package: `@brik64/core@0.1.0-beta.6.1`
+- current JS/TS SDK package: `@brik64/core@0.1.0-beta.7`
 - current docs: https://docs.brik64.com
 - older public examples may still carry compatibility aliases; report drift
   instead of presenting legacy names as current truth

--- a/skills/brik64-javascript/SKILL.md
+++ b/skills/brik64-javascript/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brik64-javascript
 description: "Historical JavaScript/TypeScript Digital Circuitality patterns for BRIK64 work. Check docs.brik64.com and the current public brik64 skill before installing packages or making SDK, certification, catalog, or extended-operation claims."
-version: 0.1.0-beta.6-public-reference
+version: 0.1.0-beta.7-public-reference
 ---
 
 # BRIK-64 for JavaScript / TypeScript
@@ -19,7 +19,7 @@ package availability, SDK exports, or CLI behavior as current public truth.
 
 ```bash
 # Current public CLI beta
-npm install @brik64/core@0.1.0-beta.6.1
+npm install @brik64/core@0.1.0-beta.7
 node --version
 
 # Historical SDK examples below may reference older packages or APIs.

--- a/skills/brik64-python/SKILL.md
+++ b/skills/brik64-python/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brik64-python
 description: "Historical Python Digital Circuitality patterns for BRIK64 work. Check docs.brik64.com and the current public brik64 skill before installing packages or making SDK, certification, catalog, or extended-operation claims."
-version: 0.1.0-beta.6-public-reference
+version: 0.1.0-beta.7-public-reference
 ---
 
 # BRIK-64 for Python
@@ -11,7 +11,7 @@ https://docs.brik64.com and the current `brik64` skill before presenting package
 availability, SDK exports, or CLI behavior as current public truth.
 
 **Docs:** https://docs.brik64.com
-**Package:** https://pypi.org/project/brik64/0.1.0b6/
+**Package:** https://pypi.org/project/brik64/0.1.0b7/
 
 ---
 
@@ -23,7 +23,7 @@ curl -fsSL https://brik64.com/cli/install.sh | bash
 brik64 --version
 
 # Current public Python SDK beta
-pip install brik64==0.1.0b6.post1
+pip install brik64==0.1.0b7
 ```
 
 Do not treat package installation as CLI installation or a workspace workflow.
@@ -60,7 +60,8 @@ neg       = arithmetic.neg8(1)             # 255
 power     = arithmetic.pow8(2, 7)          # 128 (saturating)
 ```
 
-> In beta6, `div8` raises `ZeroDivisionError` for division by zero.
+> Check the installed beta7 package for exact division-by-zero behavior before
+> publishing behavior-sensitive examples.
 
 ---
 

--- a/skills/brik64-rust/SKILL.md
+++ b/skills/brik64-rust/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brik64-rust
 description: "Historical Rust Digital Circuitality patterns for BRIK64 work. Check docs.brik64.com and the current public brik64 skill before installing crates or making SDK, certification, catalog, or extended-operation claims."
-version: 0.1.0-beta.6-public-reference
+version: 0.1.0-beta.7-public-reference
 ---
 
 # BRIK-64 for Rust
@@ -19,7 +19,7 @@ availability, SDK exports, or CLI behavior as current public truth.
 
 ```toml
 [dependencies]
-brik64-core = "0.1.0-beta.6.1"
+brik64-core = "0.1.0-beta.7"
 ```
 
 Or via CLI:
@@ -75,7 +75,7 @@ let n     = neg8(1);             // 255
 let p     = pow8(2, 7);          // 128 (saturating)
 ```
 
-> In beta6, confirm division-by-zero behavior against the installed crate before
+> In beta7, confirm division-by-zero behavior against the installed crate before
 > using it as public documentation. Package installation does not establish
 > CLI installation or workspace workflows.
 

--- a/skills/brik64/SKILL.md
+++ b/skills/brik64/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brik64
 description: Public BRIK64 operating skill for AI agents using the brik64 CLI, .brik traceability, PCD 1.0, local evidence, and claim-safe workflows. Use when working with BRIK64 projects, PCD files, agent instructions, CLI commands, evidence reports, or public BRIK64 documentation.
-version: 0.1.0-beta.6
+version: 0.1.0-beta.7
 triggers:
   - using brik64 CLI
   - BRIK64 project workflow
@@ -20,7 +20,7 @@ helping a user adopt the public BRIK64 CLI beta.
 
 BRIK64 is a local-first workflow for making critical software logic easier to
 inspect, describe, compose, and review with bounded evidence. The current public
-beta surface is `0.1.0-beta.6`. The CLI install channel is curl-only:
+beta surface is `0.1.0-beta.7`. The CLI install channel is curl-only:
 `curl -fsSL https://brik64.com/cli/install.sh | bash`. npm, PyPI and crates.io
 are reserved for release-backed SDK packages.
 
@@ -30,7 +30,7 @@ Primary documentation:
 - CLI install: https://docs.brik64.com/cli/install
 - GitHub Release: https://github.com/brik64/brik64-cli/releases
 - JS/TS SDK package: https://www.npmjs.com/package/@brik64/core
-- Python SDK package: https://pypi.org/project/brik64/0.1.0b6/
+- Python SDK package: https://pypi.org/project/brik64/0.1.0b7/
 - Rust SDK package: https://crates.io/crates/brik64-core
 - Public skills repo: https://github.com/brik64/brik64-tools-skills
 
@@ -87,11 +87,11 @@ brik64 help
 
 Current version boundary:
 
-- Public CLI version: `0.1.0-beta.6`
+- Public CLI version: `0.1.0-beta.7`
 - Runtime banner should be checked with `brik64 --version`.
-- JS/TS SDK package: `@brik64/core@0.1.0-beta.6.1`
-- Python SDK package: `brik64==0.1.0b6.post1`
-- Rust SDK package: `brik64-core@0.1.0-beta.6.1`
+- JS/TS SDK package: `@brik64/core@0.1.0-beta.7`
+- Python SDK package: `brik64==0.1.0b7`
+- Rust SDK package: `brik64-core@0.1.0-beta.7`
 
 Treat runtime output as observed evidence. Treat the installer route and GitHub
 Release as the public CLI surface. Treat npm, PyPI and crates.io as SDK-only

--- a/skills/pcd-system/SKILL.md
+++ b/skills/pcd-system/SKILL.md
@@ -6,7 +6,7 @@ triggers:
   - using brik CLI public beta
   - reviewing PCD examples
   - checking current docs before public claims
-version: 0.1.0-beta.6-public-reference
+version: 0.1.0-beta.7-public-reference
 ---
 
 # PCD System — Public Beta Reference Notes
@@ -17,14 +17,14 @@ https://docs.brik64.com before making release, command, or capability claims.
 
 Current public CLI command: `brik64`.
 Compatibility alias: `brik`.
-Current public CLI version: `0.1.0-beta.6`; verify public release status
+Current public CLI version: `0.1.0-beta.7`; verify public release status
 against docs and GitHub before presenting it as published.
 Current public CLI install path: `curl -fsSL https://brik64.com/cli/install.sh | bash`.
 Do not use npm to install the CLI. npm is reserved for SDK packages.
 
 Current public surface:
 
-- `brik` CLI public beta
+- `brik64` CLI public beta
 - `.brik` local traceability metadata
 - PCD 1.0 public standard: https://github.com/brik64/pcd-standard
 - agent workflows that point to docs.brik64.com
@@ -46,10 +46,12 @@ Roadmap or non-current surface unless separately published:
 ```bash
 curl -fsSL https://brik64.com/cli/install.sh | bash
 brik64 --version
-brik help
-brik init
-brik certify path/to/program.pcd
-brik emit path/to/program.pcd
+brik64 help
+brik64 init
+brik64 certify path/to/program.pcd
+brik64 verify path/to/program.pcd
+brik64 emit path/to/program.pcd
+brik64 polymerize path/to/program.pcd --out polymer.pcd
 ```
 
 ## PCD Orientation


### PR DESCRIPTION
## Summary

Aligns this repository with the BRIK64 beta7 release train.

## Verification

- Local beta7 release-train dry-run passes from `brik64-cli`.
- This PR is part of the coordinated beta7 train across CLI, SDKs, docs, web, and skills.

## Release Boundary

Do not treat this PR alone as public release completion. Public beta7 requires the coordinated train to merge, SDK marketplaces to publish, curl/GCP installer to serve beta7, and post-publication live verification to pass.
