### PR TITLE
Sync public skills for beta12

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Public naming contract:
 - current public CLI command: `brik64`
 - compatibility CLI alias: `brik`
 - current public CLI install path: `curl -fsSL https://brik64.com/cli/install.sh | bash`
-- current JS/TS SDK package: `@brik64/core@0.1.0-beta.11`
+- current JS/TS SDK package: `@brik64/core@0.1.0-beta.12`
 - current docs: https://docs.brik64.com
 - older public examples may still carry compatibility aliases; report drift
   instead of presenting legacy names as current truth
@@ -62,7 +62,7 @@ Install when: you are an AI coding agent, reviewing a BRIK64 project, using
 ---
 
 ### `digital-circuitality`
-**The circuit thinking methodology — language agnostic.**
+**The circuit thinking practice — language agnostic.**
 
 Teaches you to think in terms of closed circuits: bounded inputs, verified operations, proven output ranges. No undefined behavior by construction. Use this skill to understand WHY Digital Circuitality exists and how to apply circuit design principles to any language or system.
 

--- a/skills/brik64-javascript/SKILL.md
+++ b/skills/brik64-javascript/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brik64-javascript
 description: "Historical JavaScript/TypeScript Digital Circuitality patterns for BRIK64 work. Check docs.brik64.com and the current public brik64 skill before installing packages or making SDK, certification, catalog, or extended-operation claims."
-version: 0.1.0-beta.11-public-reference
+version: 0.1.0-beta.12-public-reference
 ---
 
 # BRIK-64 for JavaScript / TypeScript
@@ -19,7 +19,7 @@ package availability, SDK exports, or CLI behavior as current public truth.
 
 ```bash
 # Current public CLI beta
-npm install @brik64/core@0.1.0-beta.11
+npm install @brik64/core@0.1.0-beta.12
 node --version
 
 # Historical SDK examples below may reference older packages or APIs.
@@ -167,7 +167,7 @@ const digest = mc.string.concat(
 );
 ```
 
-### Circuit-closed function (methodology without library)
+### Circuit-closed function (practice without library)
 
 ```typescript
 // Apply circuit thinking without the library
@@ -195,7 +195,7 @@ function safeParse(json: string): { ok: true; data: unknown } | { ok: false; err
 
 ## Important Distinction
 
-Using these patterns applies Digital Circuitality **as a methodology** in your
+Using these patterns applies Digital Circuitality **as a practice** in your
 JS/TS code:
 
 - ✅ Saturating arithmetic (no overflow bugs in bitwise operations)
@@ -225,7 +225,7 @@ This is what makes Φ_c = 1 possible.
 - **Product**: cartesian product for multi-input operations
 
 Without bounded domains, the design remains open-ended. Treat domain notes here
-as methodology guidance, not as a public certification claim.
+as practice guidance, not as a public certification claim.
 
 ### You Are the Circuit Designer
 

--- a/skills/brik64-python/SKILL.md
+++ b/skills/brik64-python/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brik64-python
 description: "Historical Python Digital Circuitality patterns for BRIK64 work. Check docs.brik64.com and the current public brik64 skill before installing packages or making SDK, certification, catalog, or extended-operation claims."
-version: 0.1.0-beta.11-public-reference
+version: 0.1.0-beta.12-public-reference
 ---
 
 # BRIK-64 for Python
@@ -11,7 +11,7 @@ https://docs.brik64.com and the current `brik64` skill before presenting package
 availability, SDK exports, or CLI behavior as current public truth.
 
 **Docs:** https://docs.brik64.com
-**Package:** https://pypi.org/project/brik64/0.1.0b11/
+**Package:** https://pypi.org/project/brik64/0.1.0b12/
 
 ---
 
@@ -23,7 +23,7 @@ curl -fsSL https://brik64.com/cli/install.sh | bash
 brik64 --version
 
 # Current public Python SDK beta
-pip install brik64==0.1.0b11
+pip install brik64==0.1.0b12
 ```
 
 Do not treat package installation as CLI installation or a workspace workflow.
@@ -154,7 +154,7 @@ label = eva.cond(
 
 ## Integration Patterns
 
-### Circuit-closed function (methodology without library)
+### Circuit-closed function (practice without library)
 
 ```python
 # Apply circuit thinking — every branch returns, domain guarded
@@ -180,7 +180,7 @@ def safe_divide(a: int, b: int) -> Union[int, str]:
 
 ## Important Distinction
 
-Using `brik64` applies Digital Circuitality **as a methodology** in your Python code:
+Using `brik64` applies Digital Circuitality **as a practice** in your Python code:
 
 - ✅ Bounded arithmetic examples
 - ✅ Explicit crypto operation boundaries
@@ -200,7 +200,7 @@ For PCD guidance, use the current `brik64` skill and docs.brik64.com.
 ## Closure Domains
 
 Every monomer declares its domain: the bounded set of valid inputs and outputs.
-This is methodology guidance for keeping examples explicit and reviewable.
+This is practice guidance for keeping examples explicit and reviewable.
 
 - **Range**: `[0, 255]` for u8 operations
 - **Set**: `{true, false}` for boolean operations  
@@ -208,7 +208,7 @@ This is methodology guidance for keeping examples explicit and reviewable.
 - **Product**: cartesian product for multi-input operations
 
 Without bounded domains, the design remains open-ended. Treat domain notes here
-as methodology guidance, not as a public certification claim.
+as practice guidance, not as a public certification claim.
 
 ### You Are the Circuit Designer
 

--- a/skills/brik64-rust/SKILL.md
+++ b/skills/brik64-rust/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brik64-rust
 description: "Historical Rust Digital Circuitality patterns for BRIK64 work. Check docs.brik64.com and the current public brik64 skill before installing crates or making SDK, certification, catalog, or extended-operation claims."
-version: 0.1.0-beta.11-public-reference
+version: 0.1.0-beta.12-public-reference
 ---
 
 # BRIK-64 for Rust
@@ -19,7 +19,7 @@ availability, SDK exports, or CLI behavior as current public truth.
 
 ```toml
 [dependencies]
-brik64-core = "0.1.0-beta.11"
+brik64-core = "0.1.0-beta.12"
 ```
 
 Or via CLI:
@@ -199,7 +199,7 @@ fn hash_and_sign(data: &[u8], key: &PrivateKey) -> (Hash32, Signature) {
 }
 ```
 
-### Circuit-closed function (methodology without library)
+### Circuit-closed function (practice without library)
 
 ```rust
 // Apply circuit thinking without the library
@@ -219,7 +219,7 @@ fn process(input: &str) -> Result<String, String> {
 
 ## Important Distinction
 
-Using `brik64` applies Digital Circuitality **as a methodology** inside your Rust code. This gives you:
+Using `brik64` applies Digital Circuitality **as a practice** inside your Rust code. This gives you:
 
 - ✅ Bounded arithmetic examples
 - ✅ explicit crypto operation boundaries
@@ -241,7 +241,7 @@ For PCD guidance, use the current `brik64` skill and docs.brik64.com.
 ## Closure Domains
 
 Every monomer declares its domain: the bounded set of valid inputs and outputs.
-This is methodology guidance for keeping examples explicit and reviewable.
+This is practice guidance for keeping examples explicit and reviewable.
 
 - **Range**: `[0, 255]` for u8 operations
 - **Set**: `{true, false}` for boolean operations  
@@ -249,7 +249,7 @@ This is methodology guidance for keeping examples explicit and reviewable.
 - **Product**: cartesian product for multi-input operations
 
 Without bounded domains, the design remains open-ended. Treat domain notes here
-as methodology guidance, not as a public certification claim.
+as practice guidance, not as a public certification claim.
 
 ### You Are the Circuit Designer
 

--- a/skills/brik64/SKILL.md
+++ b/skills/brik64/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brik64
 description: Public BRIK64 operating skill for AI agents using the brik64 CLI, .brik traceability, PCD 1.0, local evidence, and claim-safe workflows. Use when working with BRIK64 projects, PCD files, agent instructions, CLI commands, evidence reports, or public BRIK64 documentation.
-version: 0.1.0-beta.11
+version: 0.1.0-beta.12
 triggers:
   - using brik64 CLI
   - BRIK64 project workflow
@@ -20,7 +20,7 @@ helping a user adopt the public BRIK64 CLI beta.
 
 BRIK64 is a local-first workflow for making critical software logic easier to
 inspect, describe, compose, and review with bounded evidence. The current public
-beta surface is `0.1.0-beta.11`. The CLI install channel is curl-only:
+beta surface is `0.1.0-beta.12`. The CLI install channel is curl-only:
 `curl -fsSL https://brik64.com/cli/install.sh | bash`. npm, PyPI and crates.io
 are reserved for release-backed SDK packages.
 
@@ -30,7 +30,7 @@ Primary documentation:
 - CLI install: https://docs.brik64.com/cli/install
 - GitHub Release: https://github.com/brik64/brik64-cli/releases
 - JS/TS SDK package: https://www.npmjs.com/package/@brik64/core
-- Python SDK package: https://pypi.org/project/brik64/0.1.0b11/
+- Python SDK package: https://pypi.org/project/brik64/0.1.0b12/
 - Rust SDK package: https://crates.io/crates/brik64-core
 - Public skills repo: https://github.com/brik64/brik64-tools-skills
 
@@ -87,11 +87,11 @@ brik64 help
 
 Current version boundary:
 
-- Public CLI version: `0.1.0-beta.11`
+- Public CLI version: `0.1.0-beta.12`
 - Runtime banner should be checked with `brik64 --version`.
-- JS/TS SDK package: `@brik64/core@0.1.0-beta.11`
-- Python SDK package: `brik64==0.1.0b11`
-- Rust SDK package: `brik64-core@0.1.0-beta.11`
+- JS/TS SDK package: `@brik64/core@0.1.0-beta.12`
+- Python SDK package: `brik64==0.1.0b12`
+- Rust SDK package: `brik64-core@0.1.0-beta.12`
 
 Treat runtime output as observed evidence. Treat the installer route and GitHub
 Release as the public CLI surface. Treat npm, PyPI and crates.io as SDK-only

--- a/skills/digital-circuitality/SKILL.md
+++ b/skills/digital-circuitality/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: digital-circuitality
-description: "Teaches the Digital Circuitality methodology — how to think and design programs as bounded, inspectable circuits in any language. No PCD or public CLI required. Check the current brik64 skill and docs.brik64.com before making CLI, SDK, catalog, certification, or formal-proof claims."
+description: "Teaches the Digital Circuitality practice — how to think and design programs as bounded, inspectable circuits in any language. No PCD or public CLI required. Check the current brik64 skill and docs.brik64.com before making CLI, SDK, catalog, certification, or formal-proof claims."
 ---
 
 # Digital Circuitality — Circuit Thinking for Any Language
 
 Apply the engineering discipline of Digital Circuitality to your code regardless
-of language. This skill is methodology guidance: it helps agents design bounded,
+of language. This skill is practice guidance: it helps agents design bounded,
 inspectable logic. It is not itself a certification surface.
 
 **Full reference:** https://docs.brik64.com/theory/digital-circuitality
@@ -340,13 +340,13 @@ Like choosing a 12-bit vs 16-bit ADC — the engineer decides the resolution. Th
 Result: precision becomes a visible engineering choice instead of an accidental
 runtime side effect.
 
-## Methodology vs. Product Evidence
+## Practice vs. Product Evidence
 
 | | Digital Circuitality (this skill) | BRIK64 product evidence |
 |---|---|---|
 | **Language** | Any (Rust, Python, JS, Go...) | Current docs and release artifacts |
 | **Verification** | discipline + code review + tests | bounded CLI reports or evidence packs when available |
-| **Public claims** | methodology only | exact artifact/version scope |
+| **Public claims** | practice only | exact artifact/version scope |
 | **Value** | clearer boundaries and fewer hidden assumptions | traceable operational evidence |
 
 > Use circuit thinking everywhere. Use current BRIK64 docs and release evidence

--- a/skills/pcd-system/SKILL.md
+++ b/skills/pcd-system/SKILL.md
@@ -6,7 +6,7 @@ triggers:
   - using brik CLI public beta
   - reviewing PCD examples
   - checking current docs before public claims
-version: 0.1.0-beta.11-public-reference
+version: 0.1.0-beta.12-public-reference
 ---
 
 # PCD System — Public Beta Reference Notes
@@ -17,7 +17,7 @@ https://docs.brik64.com before making release, command, or capability claims.
 
 Current public CLI command: `brik64`.
 Compatibility alias: `brik`.
-Current public CLI version: `0.1.0-beta.11`; verify public release status
+Current public CLI version: `0.1.0-beta.12`; verify public release status
 against docs and GitHub before presenting it as published.
 Current public CLI install path: `curl -fsSL https://brik64.com/cli/install.sh | bash`.
 Do not use npm to install the CLI. npm is reserved for SDK packages.


### PR DESCRIPTION
## Summary\n- Updates public BRIK64 skills to beta12 package coordinates.\n- Removes private/ambiguous methodology wording from public agent surfaces in favor of practice/guidance wording.\n\n## Evidence\n- npm run gate:beta12:skills-sync from brik64-cli