### PR TITLE
Align public skills to beta13

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Public naming contract:
 - current public CLI command: `brik64`
 - compatibility CLI alias: `brik`
 - current public CLI install path: `curl -fsSL https://brik64.com/cli/install.sh | bash`
-- current JS/TS SDK package: `@brik64/core@0.1.0-beta.12`
+- current JS/TS SDK package: `@brik64/core@0.1.0-beta.13`
 - current docs: https://docs.brik64.com
 - older public examples may still carry compatibility aliases; report drift
   instead of presenting legacy names as current truth

--- a/skills/brik64-javascript/SKILL.md
+++ b/skills/brik64-javascript/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brik64-javascript
 description: "Historical JavaScript/TypeScript Digital Circuitality patterns for BRIK64 work. Check docs.brik64.com and the current public brik64 skill before installing packages or making SDK, certification, catalog, or extended-operation claims."
-version: 0.1.0-beta.12-public-reference
+version: 0.1.0-beta.13-public-reference
 ---
 
 # BRIK-64 for JavaScript / TypeScript
@@ -19,7 +19,7 @@ package availability, SDK exports, or CLI behavior as current public truth.
 
 ```bash
 # Current public CLI beta
-npm install @brik64/core@0.1.0-beta.12
+npm install @brik64/core@0.1.0-beta.13
 node --version
 
 # Historical SDK examples below may reference older packages or APIs.

--- a/skills/brik64-python/SKILL.md
+++ b/skills/brik64-python/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brik64-python
 description: "Historical Python Digital Circuitality patterns for BRIK64 work. Check docs.brik64.com and the current public brik64 skill before installing packages or making SDK, certification, catalog, or extended-operation claims."
-version: 0.1.0-beta.12-public-reference
+version: 0.1.0-beta.13-public-reference
 ---
 
 # BRIK-64 for Python
@@ -11,7 +11,7 @@ https://docs.brik64.com and the current `brik64` skill before presenting package
 availability, SDK exports, or CLI behavior as current public truth.
 
 **Docs:** https://docs.brik64.com
-**Package:** https://pypi.org/project/brik64/0.1.0b12/
+**Package:** https://pypi.org/project/brik64/0.1.0b13/
 
 ---
 
@@ -23,7 +23,7 @@ curl -fsSL https://brik64.com/cli/install.sh | bash
 brik64 --version
 
 # Current public Python SDK beta
-pip install brik64==0.1.0b12
+pip install brik64==0.1.0b13
 ```
 
 Do not treat package installation as CLI installation or a workspace workflow.

--- a/skills/brik64-rust/SKILL.md
+++ b/skills/brik64-rust/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brik64-rust
 description: "Historical Rust Digital Circuitality patterns for BRIK64 work. Check docs.brik64.com and the current public brik64 skill before installing crates or making SDK, certification, catalog, or extended-operation claims."
-version: 0.1.0-beta.12-public-reference
+version: 0.1.0-beta.13-public-reference
 ---
 
 # BRIK-64 for Rust
@@ -19,7 +19,7 @@ availability, SDK exports, or CLI behavior as current public truth.
 
 ```toml
 [dependencies]
-brik64-core = "0.1.0-beta.12"
+brik64-core = "0.1.0-beta.13"
 ```
 
 Or via CLI:

--- a/skills/brik64/SKILL.md
+++ b/skills/brik64/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brik64
 description: Public BRIK64 operating skill for AI agents using the brik64 CLI, .brik traceability, PCD 1.0, local evidence, and claim-safe workflows. Use when working with BRIK64 projects, PCD files, agent instructions, CLI commands, evidence reports, or public BRIK64 documentation.
-version: 0.1.0-beta.12
+version: 0.1.0-beta.13
 triggers:
   - using brik64 CLI
   - BRIK64 project workflow
@@ -20,7 +20,7 @@ helping a user adopt the public BRIK64 CLI beta.
 
 BRIK64 is a local-first workflow for making critical software logic easier to
 inspect, describe, compose, and review with bounded evidence. The current public
-beta surface is `0.1.0-beta.12`. The CLI install channel is curl-only:
+beta surface is `0.1.0-beta.13`. The CLI install channel is curl-only:
 `curl -fsSL https://brik64.com/cli/install.sh | bash`. npm, PyPI and crates.io
 are reserved for release-backed SDK packages.
 
@@ -30,7 +30,7 @@ Primary documentation:
 - CLI install: https://docs.brik64.com/cli/install
 - GitHub Release: https://github.com/brik64/brik64-cli/releases
 - JS/TS SDK package: https://www.npmjs.com/package/@brik64/core
-- Python SDK package: https://pypi.org/project/brik64/0.1.0b12/
+- Python SDK package: https://pypi.org/project/brik64/0.1.0b13/
 - Rust SDK package: https://crates.io/crates/brik64-core
 - Public skills repo: https://github.com/brik64/brik64-tools-skills
 
@@ -87,15 +87,36 @@ brik64 help
 
 Current version boundary:
 
-- Public CLI version: `0.1.0-beta.12`
+- Public CLI version: `0.1.0-beta.13`
 - Runtime banner should be checked with `brik64 --version`.
-- JS/TS SDK package: `@brik64/core@0.1.0-beta.12`
-- Python SDK package: `brik64==0.1.0b12`
-- Rust SDK package: `brik64-core@0.1.0-beta.12`
+- JS/TS SDK package: `@brik64/core@0.1.0-beta.13`
+- Python SDK package: `brik64==0.1.0b13`
+- Rust SDK package: `brik64-core@0.1.0-beta.13`
 
 Treat runtime output as observed evidence. Treat the installer route and GitHub
 Release as the public CLI surface. Treat npm, PyPI and crates.io as SDK-only
 channels. If they disagree, report the drift instead of hiding it.
+
+## Source Lift Preview
+
+Use source lift only as a local preview path:
+
+```bash
+brik64 lift js path/to/file.js --preview
+brik64 lift ts path/to/file.ts --preview
+brik64 lift python path/to/file.py --preview
+brik64 adoption report --json
+```
+
+Rules:
+
+- `lift --preview` generates PCD candidates and warning reports under
+  `.brik/lift-preview/`.
+- It does not create certificates.
+- It does not upload source by default.
+- Unsupported constructs are warnings, not proof failures.
+- Review generated PCD candidates before using `certify`, `verify`, `emit`, or
+  `polymerize`.
 
 ## `.brik` Traceability
 

--- a/skills/pcd-system/SKILL.md
+++ b/skills/pcd-system/SKILL.md
@@ -6,7 +6,7 @@ triggers:
   - using brik CLI public beta
   - reviewing PCD examples
   - checking current docs before public claims
-version: 0.1.0-beta.12-public-reference
+version: 0.1.0-beta.13-public-reference
 ---
 
 # PCD System — Public Beta Reference Notes
@@ -17,7 +17,7 @@ https://docs.brik64.com before making release, command, or capability claims.
 
 Current public CLI command: `brik64`.
 Compatibility alias: `brik`.
-Current public CLI version: `0.1.0-beta.12`; verify public release status
+Current public CLI version: `0.1.0-beta.13`; verify public release status
 against docs and GitHub before presenting it as published.
 Current public CLI install path: `curl -fsSL https://brik64.com/cli/install.sh | bash`.
 Do not use npm to install the CLI. npm is reserved for SDK packages.


### PR DESCRIPTION
## Summary
- Updates public skills to 0.1.0-beta.13.
- Adds source lift preview guidance with claim-safe boundaries.

## Verification
- npm run gate:beta13:skills-sync from brik64-cli