### PR TITLE
Update public skills to Beta14.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Public naming contract:
 - current public CLI command: `brik64`
 - compatibility CLI alias: `brik`
 - current public CLI install path: `curl -fsSL https://brik64.com/cli/install.sh | bash`
-- current JS/TS SDK package: `@brik64/core@0.1.0-beta.14.1`
+- current JS/TS SDK package: `@brik64/core@0.1.0-beta.14.2`
 - current docs: https://docs.brik64.com
 - older public examples may still carry compatibility aliases; report drift
   instead of presenting legacy names as current truth

--- a/skills/brik64-javascript/SKILL.md
+++ b/skills/brik64-javascript/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brik64-javascript
 description: "Historical JavaScript/TypeScript Digital Circuitality patterns for BRIK64 work. Check docs.brik64.com and the current public brik64 skill before installing packages or making SDK, certification, catalog, or extended-operation claims."
-version: 0.1.0-beta.14.1-public-reference
+version: 0.1.0-beta.14.2-public-reference
 ---
 
 # BRIK-64 for JavaScript / TypeScript
@@ -19,7 +19,7 @@ package availability, SDK exports, or CLI behavior as current public truth.
 
 ```bash
 # Current public CLI beta
-npm install @brik64/core@0.1.0-beta.14.1
+npm install @brik64/core@0.1.0-beta.14.2
 node --version
 
 # Historical SDK examples below may reference older packages or APIs.

--- a/skills/brik64-python/SKILL.md
+++ b/skills/brik64-python/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brik64-python
 description: "Historical Python Digital Circuitality patterns for BRIK64 work. Check docs.brik64.com and the current public brik64 skill before installing packages or making SDK, certification, catalog, or extended-operation claims."
-version: 0.1.0-beta.14.1-public-reference
+version: 0.1.0-beta.14.2-public-reference
 ---
 
 # BRIK-64 for Python
@@ -11,7 +11,7 @@ https://docs.brik64.com and the current `brik64` skill before presenting package
 availability, SDK exports, or CLI behavior as current public truth.
 
 **Docs:** https://docs.brik64.com
-**Package:** https://pypi.org/project/brik64/0.1.0b14.post1/
+**Package:** https://pypi.org/project/brik64/0.1.0b14.post2/
 
 ---
 
@@ -23,7 +23,7 @@ curl -fsSL https://brik64.com/cli/install.sh | bash
 brik64 --version
 
 # Current public Python SDK beta
-pip install brik64==0.1.0b14.post1
+pip install brik64==0.1.0b14.post2
 ```
 
 Do not treat package installation as CLI installation or a workspace workflow.

--- a/skills/brik64-rust/SKILL.md
+++ b/skills/brik64-rust/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brik64-rust
 description: "Historical Rust Digital Circuitality patterns for BRIK64 work. Check docs.brik64.com and the current public brik64 skill before installing crates or making SDK, certification, catalog, or extended-operation claims."
-version: 0.1.0-beta.14.1-public-reference
+version: 0.1.0-beta.14.2-public-reference
 ---
 
 # BRIK-64 for Rust
@@ -19,7 +19,7 @@ availability, SDK exports, or CLI behavior as current public truth.
 
 ```toml
 [dependencies]
-brik64-core = "0.1.0-beta.14.1"
+brik64-core = "0.1.0-beta.14.2"
 ```
 
 Or via CLI:

--- a/skills/brik64/SKILL.md
+++ b/skills/brik64/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brik64
 description: Public BRIK64 operating skill for AI agents using the brik64 CLI, .brik traceability, PCD 1.0, local evidence, and claim-safe workflows. Use when working with BRIK64 projects, PCD files, agent instructions, CLI commands, evidence reports, or public BRIK64 documentation.
-version: 0.1.0-beta.14.1
+version: 0.1.0-beta.14.2
 triggers:
   - using brik64 CLI
   - BRIK64 project workflow
@@ -20,7 +20,7 @@ helping a user adopt the public BRIK64 CLI beta.
 
 BRIK64 is a local-first workflow for making critical software logic easier to
 inspect, describe, compose, and review with bounded evidence. The current public
-beta surface is `0.1.0-beta.14.1`. The CLI install channel is curl-only:
+beta surface is `0.1.0-beta.14.2`. The CLI install channel is curl-only:
 `curl -fsSL https://brik64.com/cli/install.sh | bash`. npm, PyPI and crates.io
 are reserved for release-backed SDK packages.
 
@@ -30,7 +30,7 @@ Primary documentation:
 - CLI install: https://docs.brik64.com/cli/install
 - GitHub Release: https://github.com/brik64/brik64-cli/releases
 - JS/TS SDK package: https://www.npmjs.com/package/@brik64/core
-- Python SDK package: https://pypi.org/project/brik64/0.1.0b14.post1/
+- Python SDK package: https://pypi.org/project/brik64/0.1.0b14.post2/
 - Rust SDK package: https://crates.io/crates/brik64-core
 - Public skills repo: https://github.com/brik64/brik64-tools-skills
 
@@ -90,11 +90,11 @@ brik64 help
 
 Current version boundary:
 
-- Public CLI version: `0.1.0-beta.14.1`
+- Public CLI version: `0.1.0-beta.14.2`
 - Runtime banner should be checked with `brik64 --version`.
-- JS/TS SDK package: `@brik64/core@0.1.0-beta.14.1`
-- Python SDK package: `brik64==0.1.0b14.post1`
-- Rust SDK package: `brik64-core@0.1.0-beta.14.1`
+- JS/TS SDK package: `@brik64/core@0.1.0-beta.14.2`
+- Python SDK package: `brik64==0.1.0b14.post2`
+- Rust SDK package: `brik64-core@0.1.0-beta.14.2`
 
 Treat runtime output as observed evidence. Treat the installer route and GitHub
 Release as the public CLI surface. Treat npm, PyPI and crates.io as SDK-only

--- a/skills/pcd-system/SKILL.md
+++ b/skills/pcd-system/SKILL.md
@@ -6,7 +6,7 @@ triggers:
   - using brik CLI public beta
   - reviewing PCD examples
   - checking current docs before public claims
-version: 0.1.0-beta.14.1-public-reference
+version: 0.1.0-beta.14.2-public-reference
 ---
 
 # PCD System — Public Beta Reference Notes
@@ -17,7 +17,7 @@ https://docs.brik64.com before making release, command, or capability claims.
 
 Current public CLI command: `brik64`.
 Compatibility alias: `brik`.
-Current public CLI version: `0.1.0-beta.14.1`; verify public release status
+Current public CLI version: `0.1.0-beta.14.2`; verify public release status
 against docs and GitHub before presenting it as published.
 Current public CLI install path: `curl -fsSL https://brik64.com/cli/install.sh | bash`.
 Do not use npm to install the CLI. npm is reserved for SDK packages.


### PR DESCRIPTION
## Summary
- Updates public BRIK64 skill metadata and SDK references to CLI Beta14.2.
- Updates Python SDK reference to 0.1.0b14.post2.

## Validation
- rg stale Beta14.1 references
- git diff --check