### PR TITLE
chore(skills): align brik64 skill to beta14.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Public naming contract:
 - current public CLI command: `brik64`
 - compatibility CLI alias: `brik`
 - current public CLI install path: `curl -fsSL https://brik64.com/cli/install.sh | bash`
-- current JS/TS SDK package: `@brik64/core@0.1.0-beta.14.5`
+- current JS/TS SDK package: `@brik64/core@0.1.0-beta.14.6`
 - current docs: https://docs.brik64.com
 - older public examples may still carry compatibility aliases; report drift
   instead of presenting legacy names as current truth

--- a/skills/brik64/SKILL.md
+++ b/skills/brik64/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brik64
 description: Public BRIK64 operating skill for AI agents using the brik64 CLI, .brik traceability, PCD 1.0, local evidence, and claim-safe workflows. Use when working with BRIK64 projects, PCD files, agent instructions, CLI commands, evidence reports, or public BRIK64 documentation.
-version: 0.1.0-beta.14.5
+version: 0.1.0-beta.14.6
 triggers:
   - using brik64 CLI
   - BRIK64 project workflow
@@ -20,7 +20,7 @@ helping a user adopt the public BRIK64 CLI beta.
 
 BRIK64 is a local-first workflow for making critical software logic easier to
 inspect, describe, compose, and review with bounded evidence. The current public
-beta surface is `0.1.0-beta.14.5`. The CLI install channel is curl-only:
+beta surface is `0.1.0-beta.14.6`. The CLI install channel is curl-only:
 `curl -fsSL https://brik64.com/cli/install.sh | bash`. npm, PyPI and crates.io
 are reserved for release-backed SDK packages.
 
@@ -30,7 +30,7 @@ Primary documentation:
 - CLI install: https://docs.brik64.com/cli/install
 - GitHub Release: https://github.com/brik64/brik64-cli/releases
 - JS/TS SDK package: https://www.npmjs.com/package/@brik64/core
-- Python SDK package: https://pypi.org/project/brik64/0.1.0b14.post5/
+- Python SDK package: https://pypi.org/project/brik64/0.1.0b14.post6/
 - Rust SDK package: https://crates.io/crates/brik64-core
 - Public skills repo: https://github.com/brik64/brik64-tools-skills
 
@@ -90,11 +90,11 @@ brik64 help
 
 Current version boundary:
 
-- Public CLI version: `0.1.0-beta.14.5`
+- Public CLI version: `0.1.0-beta.14.6`
 - Runtime banner should be checked with `brik64 --version`.
-- JS/TS SDK package: `@brik64/core@0.1.0-beta.14.5`
-- Python SDK package: `brik64==0.1.0b14.post5`
-- Rust SDK package: `brik64-core@0.1.0-beta.14.5`
+- JS/TS SDK package: `@brik64/core@0.1.0-beta.14.6`
+- Python SDK package: `brik64==0.1.0b14.post6`
+- Rust SDK package: `brik64-core@0.1.0-beta.14.6`
 
 Treat runtime output as observed evidence. Treat the installer route and GitHub
 Release as the public CLI surface. Treat npm, PyPI and crates.io as SDK-only


### PR DESCRIPTION
## Summary\n- Align the public brik64 skill and README SDK marker to CLI 0.1.0-beta.14.6.\n- Update Python SDK public link/version to 0.1.0b14.post6.\n\n## Verification\n- Local public skill contract grep for version, installer, npm SDK, Rust SDK.\n- Claim-safe scan for internal L/N/fixpoint terms in skills/brik64/SKILL.md.\n