### PR TITLE
Align skills with Beta15.1 ledger hotfix

### DIFF
--- a/skills/brik64/SKILL.md
+++ b/skills/brik64/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brik64
 description: Public BRIK64 operating skill for AI agents using the brik64 CLI, .brik traceability, PCD 1.0, local evidence, and claim-safe workflows. Use when working with BRIK64 projects, PCD files, agent instructions, CLI commands, evidence reports, or public BRIK64 documentation.
-version: 0.1.0-beta.15
+version: 0.1.0-beta.15.1
 triggers:
   - using brik64 CLI
   - BRIK64 project workflow
@@ -20,9 +20,9 @@ helping a user adopt the public BRIK64 CLI beta.
 
 BRIK64 is a local-first workflow for making critical software logic easier to
 inspect, describe, compose, and review with bounded evidence. The current public
-beta surface is `0.1.0-beta.15`. The CLI install channel is curl-only:
+beta surface is `0.1.0-beta.15.1`. The CLI install channel is curl-only:
 `curl -fsSL https://brik64.com/cli/install.sh | bash`. npm, PyPI, and
-crates.io carry Beta15 SDK packages.
+crates.io carry SDK packages; Beta15.1 does not require an SDK package update.
 
 Primary documentation:
 
@@ -90,7 +90,7 @@ brik64 help
 
 Current version boundary:
 
-- Public CLI version: `0.1.0-beta.15`
+- Public CLI version: `0.1.0-beta.15.1`
 - Runtime banner should be checked with `brik64 --version`.
 - JS/TS SDK package: `@brik64/core@0.1.0-beta.15`
 - Python SDK package: `brik64==0.1.0b15`
@@ -126,6 +126,7 @@ Rules:
 Use `.brik` as local project metadata for BRIK64 work:
 
 - project manifest;
+- local ledger events under `.brik/ledger/`;
 - decisions and evidence references;
 - local candidate artifacts;
 - update and release notes where supported by the CLI.
@@ -134,9 +135,13 @@ Rules:
 
 - `brik64 init` prepares local BRIK64 metadata.
 - `brik64 init` must not create or modify `AGENTS.md`.
+- `brik64 ledger verify --json` checks local event-chain consistency.
+- `brik64 ledger export --redacted` exports local ledger metadata without raw
+  source, raw PCD content, absolute paths, or secrets.
 - Do not store secrets, raw tokens, private keys, or private source snapshots in
   `.brik`.
-- Treat `.brik` metadata as operational traceability, not as certification.
+- Treat `.brik` metadata and `.brik/ledger` as operational traceability, not as
+  certification or as a distributed blockchain.
 
 ## PCD 1.0 Working Model
 

--- a/skills/pcd-system/SKILL.md
+++ b/skills/pcd-system/SKILL.md
@@ -6,7 +6,7 @@ triggers:
   - using brik CLI public beta
   - reviewing PCD examples
   - checking current docs before public claims
-version: 0.1.0-beta.15-public-reference
+version: 0.1.0-beta.15.1-public-reference
 ---
 
 # PCD System — Public Beta Reference Notes
@@ -17,7 +17,7 @@ https://docs.brik64.com before making release, command, or capability claims.
 
 Current public CLI command: `brik64`.
 Compatibility alias: `brik`.
-Current public CLI version: `0.1.0-beta.15`; verify public release status
+Current public CLI version: `0.1.0-beta.15.1`; verify public release status
 against docs and GitHub before presenting it as published.
 Current public CLI install path: `curl -fsSL https://brik64.com/cli/install.sh | bash`.
 Do not use npm to install the CLI. npm is reserved for SDK packages.


### PR DESCRIPTION
## Summary\n- updates public BRIK64 skills to v0.1.0-beta.15.1\n- adds ledger verify/export workflow guidance\n- preserves SDK Beta15 references for marketplace packages\n\n## Verification\n- claim-safety scan for private terms only returns negative boundary references or SDK Beta15 references\n\n## Boundary\n- public skill guidance only; no internal methodology or claim-bearing language.