### PR TITLE
Align public skills to BRIK64 beta15.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Public naming contract:
 - current public CLI command: `brik64`
 - compatibility CLI alias: `brik`
 - current public CLI install path: `curl -fsSL https://brik64.com/cli/install.sh | bash`
-- current JS/TS SDK package: `@brik64/core@0.1.0-beta.15.5`
+- current JS/TS SDK package: `@brik64/core@0.1.0-beta.15.6`
 - current docs: https://docs.brik64.com
 - older public examples may still carry compatibility aliases; report drift
   instead of presenting legacy names as current truth

--- a/skills/brik64/SKILL.md
+++ b/skills/brik64/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brik64
 description: Public BRIK64 operating skill for AI agents using the brik64 CLI, .brik traceability, PCD 1.0, local evidence, and claim-safe workflows. Use when working with BRIK64 projects, PCD files, agent instructions, CLI commands, evidence reports, or public BRIK64 documentation.
-version: 0.1.0-beta.15.5
+version: 0.1.0-beta.15.6
 triggers:
   - using brik64 CLI
   - BRIK64 project workflow
@@ -20,7 +20,7 @@ helping a user adopt the public BRIK64 CLI beta.
 
 BRIK64 is a local-first workflow for making critical software logic easier to
 inspect, describe, compose, and review with bounded evidence. The current public
-beta surface is `0.1.0-beta.15.5`. The CLI install channel is curl-only:
+beta surface is `0.1.0-beta.15.6`. The CLI install channel is curl-only:
 `curl -fsSL https://brik64.com/cli/install.sh | bash`. npm, PyPI, and
 crates.io carry SDK packages. Treat the live installer output as authoritative
 for the current public beta.
@@ -91,11 +91,11 @@ brik64 help
 
 Current version boundary:
 
-- Public CLI version: `0.1.0-beta.15.5`
+- Public CLI version: `0.1.0-beta.15.6`
 - Runtime banner should be checked with `brik64 --version`.
-- JS/TS SDK package: `@brik64/core@0.1.0-beta.15.5`.
-- Python SDK package: `brik64==0.1.0b15.post5` unless the release report says Beta15.5 SDK publication is required.
-- Rust SDK package: `brik64-core@0.1.0-beta.15.5`.
+- JS/TS SDK package: `@brik64/core@0.1.0-beta.15.6`.
+- Python SDK package: `brik64==0.1.0b15.post6` unless the release report says Beta15.6 SDK publication is required.
+- Rust SDK package: `brik64-core@0.1.0-beta.15.6`.
 
 Treat runtime output as observed evidence. Treat the installer route and GitHub
 Release as the public CLI surface. Treat npm, PyPI and crates.io as SDK-only

--- a/skills/pcd-system/SKILL.md
+++ b/skills/pcd-system/SKILL.md
@@ -6,7 +6,7 @@ triggers:
   - using brik CLI public beta
   - reviewing PCD examples
   - checking current docs before public claims
-version: 0.1.0-beta.15.1-public-reference
+version: 0.1.0-beta.15.6-public-reference
 ---
 
 # PCD System — Public Beta Reference Notes
@@ -17,7 +17,7 @@ https://docs.brik64.com before making release, command, or capability claims.
 
 Current public CLI command: `brik64`.
 Compatibility alias: `brik`.
-Current public CLI version: `0.1.0-beta.15.1`; verify public release status
+Current public CLI version: `0.1.0-beta.15.6`; verify public release status
 against docs and GitHub before presenting it as published.
 Current public CLI install path: `curl -fsSL https://brik64.com/cli/install.sh | bash`.
 Do not use npm to install the CLI. npm is reserved for SDK packages.


### PR DESCRIPTION
Updates public agent skill references to Beta15.6 and current SDK coordinates without adding internal engine claims. Validation: stale-version and private-claim grep clean.