### PR TITLE
Sync public skills to Beta16

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Public naming contract:
 - current public CLI command: `brik64`
 - compatibility CLI alias: `brik`
 - current public CLI install path: `curl -fsSL https://brik64.com/cli/install.sh | bash`
-- current JS/TS SDK package: `@brik64/core@0.1.0-beta.15.7.1`
+- current JS/TS SDK package: `@brik64/core@0.1.0-beta.16`
 - current docs: https://docs.brik64.com
 - older public examples may still carry compatibility aliases; report drift
   instead of presenting legacy names as current truth

--- a/skills/brik64-javascript/SKILL.md
+++ b/skills/brik64-javascript/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brik64-javascript
 description: "Historical JavaScript/TypeScript Digital Circuitality patterns for BRIK64 work. Check docs.brik64.com and the current public brik64 skill before installing packages or making SDK, certification, catalog, or extended-operation claims."
-version: 0.1.0-beta.15-public-reference
+version: 0.1.0-beta.16-public-reference
 ---
 
 # BRIK-64 for JavaScript / TypeScript
@@ -19,7 +19,7 @@ package availability, SDK exports, or CLI behavior as current public truth.
 
 ```bash
 # Current public CLI beta
-npm install @brik64/core@0.1.0-beta.15
+npm install @brik64/core@0.1.0-beta.16
 node --version
 
 # Historical SDK examples below may reference older packages or APIs.

--- a/skills/brik64-python/SKILL.md
+++ b/skills/brik64-python/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brik64-python
 description: "Historical Python Digital Circuitality patterns for BRIK64 work. Check docs.brik64.com and the current public brik64 skill before installing packages or making SDK, certification, catalog, or extended-operation claims."
-version: 0.1.0-beta.15-public-reference
+version: 0.1.0-beta.16-public-reference
 ---
 
 # BRIK-64 for Python
@@ -11,7 +11,7 @@ https://docs.brik64.com and the current `brik64` skill before presenting package
 availability, SDK exports, or CLI behavior as current public truth.
 
 **Docs:** https://docs.brik64.com
-**Package:** https://pypi.org/project/brik64/0.1.0b15/
+**Package:** https://pypi.org/project/brik64/0.1.0b16/
 
 ---
 
@@ -23,7 +23,7 @@ curl -fsSL https://brik64.com/cli/install.sh | bash
 brik64 --version
 
 # Current public Python SDK beta
-pip install brik64==0.1.0b15
+pip install brik64==0.1.0b16
 ```
 
 Do not treat package installation as CLI installation or a workspace workflow.
@@ -60,7 +60,7 @@ neg       = arithmetic.neg8(1)             # 255
 power     = arithmetic.pow8(2, 7)          # 128 (saturating)
 ```
 
-> Check the installed Beta15 public beta package for exact division-by-zero behavior before
+> Check the installed Beta16 public beta package for exact division-by-zero behavior before
 > publishing behavior-sensitive examples.
 
 ---

--- a/skills/brik64-rust/SKILL.md
+++ b/skills/brik64-rust/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brik64-rust
 description: "Historical Rust Digital Circuitality patterns for BRIK64 work. Check docs.brik64.com and the current public brik64 skill before installing crates or making SDK, certification, catalog, or extended-operation claims."
-version: 0.1.0-beta.15-public-reference
+version: 0.1.0-beta.16-public-reference
 ---
 
 # BRIK-64 for Rust
@@ -19,7 +19,7 @@ availability, SDK exports, or CLI behavior as current public truth.
 
 ```toml
 [dependencies]
-brik64-core = "0.1.0-beta.15"
+brik64-core = "0.1.0-beta.16"
 ```
 
 Or via CLI:
@@ -75,7 +75,7 @@ let n     = neg8(1);             // 255
 let p     = pow8(2, 7);          // 128 (saturating)
 ```
 
-> In Beta15 public beta, confirm division-by-zero behavior against the installed crate before
+> In Beta16 public beta, confirm division-by-zero behavior against the installed crate before
 > using it as public documentation. Package installation does not establish
 > CLI installation or workspace workflows.
 

--- a/skills/brik64/SKILL.md
+++ b/skills/brik64/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brik64
 description: Public BRIK64 operating skill for AI agents using the brik64 CLI, .brik traceability, PCD 1.0, local evidence, and claim-safe workflows. Use when working with BRIK64 projects, PCD files, agent instructions, CLI commands, evidence reports, or public BRIK64 documentation.
-version: 0.1.0-beta.15.7.1
+version: 0.1.0-beta.16
 triggers:
   - using brik64 CLI
   - BRIK64 project workflow
@@ -20,7 +20,8 @@ helping a user adopt the public BRIK64 CLI beta.
 
 BRIK64 is a local-first workflow for making critical software logic easier to
 inspect, describe, compose, and review with bounded evidence. The current public
-beta surface is `0.1.0-beta.15.7.1`. The CLI install channel is curl-only:
+beta surface is `0.1.0-beta.16`. The local/offline CLI runtime path is `L4+N5`.
+The CLI install channel is curl-only:
 `curl -fsSL https://brik64.com/cli/install.sh | bash`. npm, PyPI, and
 crates.io carry SDK packages. Treat the live installer output as authoritative
 for the current public beta.
@@ -31,7 +32,7 @@ Primary documentation:
 - CLI install: https://docs.brik64.com/cli/install
 - GitHub Release: https://github.com/brik64/brik64-cli/releases
 - JS/TS SDK package: https://www.npmjs.com/package/@brik64/core
-- Python SDK package: https://pypi.org/project/brik64/0.1.0b15/
+- Python SDK package: https://pypi.org/project/brik64/0.1.0b16/
 - Rust SDK package: https://crates.io/crates/brik64-core
 - Public skills repo: https://github.com/brik64/brik64-tools-skills
 
@@ -91,15 +92,25 @@ brik64 help
 
 Current version boundary:
 
-- Public CLI version: `0.1.0-beta.15.7.1`
+- Public CLI version: `0.1.0-beta.16`
 - Runtime banner should be checked with `brik64 --version`.
-- JS/TS SDK package: `@brik64/core@0.1.0-beta.15.7.1`.
-- Python SDK package: `brik64==0.1.0b15.post701` unless the release report says Beta15.7.1 SDK publication is required.
-- Rust SDK package: `brik64-core@0.1.0-beta.15.7.1`.
+- JS/TS SDK package: `@brik64/core@0.1.0-beta.16`.
+- Python SDK package: `brik64==0.1.0b16` unless the release report says Beta16 SDK publication is required.
+- Rust SDK package: `brik64-core@0.1.0-beta.16`.
 
 Treat runtime output as observed evidence. Treat the installer route and GitHub
 Release as the public CLI surface. Treat npm, PyPI and crates.io as SDK-only
 channels. If they disagree, report the drift instead of hiding it.
+
+Runtime boundary:
+
+- The free/local CLI path uses `L4+N5` and must work without login after
+  installation.
+- `L5+N5` is reserved for future paid/cloud platform workflows and must not be
+  presented as the local downloadable engine.
+- Do not mention internal generation factories, self-hosting, fixpoint,
+  formal N5, or toolchain independence as public claims unless the current
+  docs and fresh release evidence explicitly authorize that wording.
 
 ## Source Lift Preview
 

--- a/skills/pcd-system/SKILL.md
+++ b/skills/pcd-system/SKILL.md
@@ -6,7 +6,7 @@ triggers:
   - using brik CLI public beta
   - reviewing PCD examples
   - checking current docs before public claims
-version: 0.1.0-beta.15.6-public-reference
+version: 0.1.0-beta.16-public-reference
 ---
 
 # PCD System — Public Beta Reference Notes
@@ -17,7 +17,7 @@ https://docs.brik64.com before making release, command, or capability claims.
 
 Current public CLI command: `brik64`.
 Compatibility alias: `brik`.
-Current public CLI version: `0.1.0-beta.15.6`; verify public release status
+Current public CLI version: `0.1.0-beta.16`; verify public release status
 against docs and GitHub before presenting it as published.
 Current public CLI install path: `curl -fsSL https://brik64.com/cli/install.sh | bash`.
 Do not use npm to install the CLI. npm is reserved for SDK packages.


### PR DESCRIPTION
Updates public BRIK64 skills to the Beta16 CLI/SDK coordinate set and keeps runtime/claim boundaries explicit.\n\n- CLI: 0.1.0-beta.16\n- JS/TS SDK: @brik64/core@0.1.0-beta.16\n- Python SDK: brik64==0.1.0b16\n- Rust SDK: brik64-core@0.1.0-beta.16\n- Local/free runtime boundary: L4+N5\n- L5+N5 remains future paid/cloud path\n- No public claims for fixpoint, self-hosting, formal N5, or toolchain independence.